### PR TITLE
[#157] Fix documentation publishing process

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,7 @@ node {
                     cd ../../
                     '''
 
-                    sh "cd legion && cp -rf docs/build/html/ \"${params.LocalDocumentationStorage}\$(python3 -c 'import legion; print(legion.__version__);')/\""
+                    sh "cd legion && cp -rf docs/build/html/ \"${params.LocalDocumentationStorage}\$(../.venv/bin/python3 -c 'import legion; print(legion.__version__);')/\""
                 }, 'Run Python code analyzers': {
                     sh '''
                     cd legion


### PR DESCRIPTION
This closes #157 

Wrong python interpreter (default) call has been changed to correct (python in virtualenv)