### PR TITLE
[#152] Production ready serving for edi

### DIFF
--- a/deploy/helms/legion/templates/edi/edi-server.yaml
+++ b/deploy/helms/legion/templates/edi/edi-server.yaml
@@ -78,7 +78,8 @@ spec:
     component: "{{ .Release.Name }}-edi"
   ports:
   - name: api
-    port: 5000
+    targetPort: 5000
+    port: 80
     protocol: TCP
 ---
 {{- if .Values.edi.ingress.enabled -}}
@@ -104,14 +105,14 @@ spec:
         paths:
           - backend:
               serviceName: "{{ .Release.Name }}-edi"
-              servicePort: 5000
+              servicePort: 80
     {{- if .Values.addLocalDomain }}
     - host: "{{ .Values.edi.ingress.domain.partial }}.local.{{ .Values.rootDomain }}"
       http:
         paths:
           - backend:
               serviceName: "{{ .Release.Name }}-edi"
-              servicePort: 5000
+              servicePort: 80
     {{- end }}
   {{- if .Values.edi.ingress.tls.enabled }}
   tls:

--- a/deploy/helms/legion/templates/edi/edi-server.yaml
+++ b/deploy/helms/legion/templates/edi/edi-server.yaml
@@ -40,7 +40,9 @@ spec:
         - name: LEGION_API_ADDR 
           value: "0.0.0.0"
         - name: LEGION_API_PORT
-          value: "80"
+          value: "5000"
+        - name: VERBOSE
+          value: "1"
         volumeMounts:
         - mountPath: /var/run/docker.sock
           name: docker-socket 
@@ -51,13 +53,13 @@ spec:
           name: cluster-state
           readOnly: true
         ports:
-        - containerPort: 80
+        - containerPort: 5000
           name: api
           protocol: TCP
         livenessProbe:
           httpGet:
             path: /
-            port: 80
+            port: 5000
           initialDelaySeconds: 120
           timeoutSeconds: 8
           failureThreshold: 5
@@ -76,7 +78,7 @@ spec:
     component: "{{ .Release.Name }}-edi"
   ports:
   - name: api
-    port: 80
+    port: 5000
     protocol: TCP
 ---
 {{- if .Values.edi.ingress.enabled -}}
@@ -102,14 +104,14 @@ spec:
         paths:
           - backend:
               serviceName: "{{ .Release.Name }}-edi"
-              servicePort: 80
+              servicePort: 5000
     {{- if .Values.addLocalDomain }}
     - host: "{{ .Values.edi.ingress.domain.partial }}.local.{{ .Values.rootDomain }}"
       http:
         paths:
           - backend:
               serviceName: "{{ .Release.Name }}-edi"
-              servicePort: 80
+              servicePort: 5000
     {{- end }}
   {{- if .Values.edi.ingress.tls.enabled }}
   tls:

--- a/k8s/edi/Dockerfile
+++ b/k8s/edi/Dockerfile
@@ -28,17 +28,48 @@ RUN add-apt-repository \
 
 RUN apt-get update && apt-get install --yes docker-ce
 
+# Standard set up Nginx
+ENV NGINX_VERSION 1.13.7-1~stretch
+ENV NJS_VERSION   1.13.7.0.1.15-1~stretch
+
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install --no-install-recommends --no-install-suggests -y nginx libpcre3 libpcre3-dev
+
+# forward request and error logs to docker log collector
+RUN ln -sf /dev/stdout /var/log/nginx/access.log \
+	&& ln -sf /dev/stderr /var/log/nginx/error.log
+
+EXPOSE 5000
+
+# Install uWSGI
+RUN pip install uwsgi
+
+# Make NGINX run on the foreground
+RUN echo "daemon off;" >> /etc/nginx/nginx.conf
+
+COPY nginx.conf /etc/nginx/conf.d/
+COPY uwsgi.ini /etc/uwsgi/
+
+RUN apt-get update && apt-get install -y supervisor
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+ENV UWSGI_INI /usr/local/lib/python3.5/dist-packages/legion/uwsgi.ini
+
+ENV NGINX_MAX_UPLOAD 0
+
+ENV LISTEN_PORT 5000
+
+COPY chmod-docker-and-run-edi.sh /usr/local/bin/chmod-docker-and-run-edi.sh
+RUN chmod a+rwx /usr/local/bin/chmod-docker-and-run-edi.sh
+ENTRYPOINT ["/usr/local/bin/chmod-docker-and-run-edi.sh"]
+
+COPY app_uwsgi.ini /usr/local/lib/python3.5/dist-packages/legion/uwsgi.ini
+RUN rm /etc/nginx/sites-enabled/default
+
+CMD ["/usr/bin/supervisord"]
 
 ARG pip_extra_index_params=""
 ARG pip_legion_version_string=""
 
 RUN pip install $pip_extra_index_params legion$pip_legion_version_string
-
-ENV TINI_VERSION v0.16.1
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
-ENTRYPOINT ["/tini", "--"]
-
-COPY chmod-docker-and-run-edi.sh /usr/local/bin/chmod-docker-and-run-edi.sh
-RUN chmod a+rwx /usr/local/bin/chmod-docker-and-run-edi.sh
-CMD ["/usr/local/bin/chmod-docker-and-run-edi.sh"]

--- a/k8s/edi/app_uwsgi.ini
+++ b/k8s/edi/app_uwsgi.ini
@@ -1,0 +1,4 @@
+[uwsgi]
+wsgi-file=/usr/local/lib/python3.5/dist-packages/legion/edi/wsgi.py
+chown-socket = root:root
+processes = 5

--- a/k8s/edi/chmod-docker-and-run-edi.sh
+++ b/k8s/edi/chmod-docker-and-run-edi.sh
@@ -3,4 +3,15 @@ set -e
 
 chmod a+rwx /var/run/docker.sock
 
-exec "edi" "--verbose"
+# Get the maximum upload file size for Nginx, default to 0: unlimited
+USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
+# Generate Nginx config for maximum upload file size
+echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
+
+# Get the listen port for Nginx, default to 80
+USE_LISTEN_PORT=${LISTEN_PORT:-80}
+# Modify Nignx config for listen port
+if ! grep -q "listen ${USE_LISTEN_PORT};" /etc/nginx/conf.d/nginx.conf ; then
+    sed -i -e "/server {/a\    listen ${USE_LISTEN_PORT};" /etc/nginx/conf.d/nginx.conf
+fi
+exec "$@"

--- a/k8s/edi/nginx.conf
+++ b/k8s/edi/nginx.conf
@@ -1,0 +1,6 @@
+server {
+    location / {
+        include uwsgi_params;
+        uwsgi_pass unix:///tmp/uwsgi.sock;
+    }
+}

--- a/k8s/edi/supervisord.conf
+++ b/k8s/edi/supervisord.conf
@@ -1,0 +1,16 @@
+[supervisord]
+nodaemon=true
+
+[program:uwsgi]
+command=/usr/local/bin/uwsgi --ini /etc/uwsgi/uwsgi.ini --die-on-term
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:nginx]
+command=/usr/sbin/nginx
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/k8s/edi/uwsgi.ini
+++ b/k8s/edi/uwsgi.ini
@@ -1,0 +1,6 @@
+[uwsgi]
+socket = /tmp/uwsgi.sock
+chown-socket = www-data:www-data
+chmod-socket = 664
+cheaper = 2
+processes = 16

--- a/legion/legion/edi/wsgi.py
+++ b/legion/legion/edi/wsgi.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+#
+#    Copyright 2017 EPAM Systems
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+"""
+Entry point for WSGI server
+"""
+
+try:
+    import docker_bootup
+except ImportError:
+    pass
+
+from legion.logging import redirect_to_stdout, set_log_level
+from legion.edi.server import init_application
+
+set_log_level()
+redirect_to_stdout()
+
+application = init_application()


### PR DESCRIPTION
This closes #152 

Built-in flask HTTP server has been replaced with nginx uwsgi