### PR TITLE
Enable dex auth on enclave grafana ingress

### DIFF
--- a/deploy/ansible/roles/legion_enclave/templates/legion-values.yaml.j2
+++ b/deploy/ansible/roles/legion_enclave/templates/legion-values.yaml.j2
@@ -19,6 +19,7 @@ grafana:
     tls:
       enabled: {% if use_https == "yes" %}true{% else %}false{% endif %}
 {% if dex.enabled == true %}
+
     annotations:
       nginx.ingress.kubernetes.io/auth-signin: https://auth.{{ cluster_name }}/oauth2/start?rd=https://$host$request_uri$is_args$args
       nginx.ingress.kubernetes.io/auth-url: http://oauth2-proxy.kube-system.svc.cluster.local:4180/oauth2/auth

--- a/deploy/ansible/roles/legion_enclave/templates/legion-values.yaml.j2
+++ b/deploy/ansible/roles/legion_enclave/templates/legion-values.yaml.j2
@@ -18,6 +18,14 @@ grafana:
   ingress:
     tls:
       enabled: {% if use_https == "yes" %}true{% else %}false{% endif %}
+{% if dex.enabled == true %}
+  annotations:
+    nginx.ingress.kubernetes.io/auth-signin: https://auth.{{ cluster_name }}/oauth2/start?rd=https://$host$request_uri$is_args$args
+    nginx.ingress.kubernetes.io/auth-url: http://oauth2-proxy.kube-system.svc.cluster.local:4180/oauth2/auth
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      auth_request_set $token $upstream_http_authorization;
+      proxy_set_header Authorization $token;
+{% endif %}
 
 edge:
   enabled: true

--- a/deploy/ansible/roles/legion_enclave/templates/legion-values.yaml.j2
+++ b/deploy/ansible/roles/legion_enclave/templates/legion-values.yaml.j2
@@ -23,9 +23,6 @@ grafana:
     annotations:
       nginx.ingress.kubernetes.io/auth-signin: https://auth.{{ cluster_name }}/oauth2/start?rd=https://$host$request_uri$is_args$args
       nginx.ingress.kubernetes.io/auth-url: http://oauth2-proxy.kube-system.svc.cluster.local:4180/oauth2/auth
-      nginx.ingress.kubernetes.io/configuration-snippet: |
-        auth_request_set $token $upstream_http_authorization;
-        proxy_set_header Authorization $token;
 {% endif %}
 
 edge:

--- a/deploy/ansible/roles/legion_enclave/templates/legion-values.yaml.j2
+++ b/deploy/ansible/roles/legion_enclave/templates/legion-values.yaml.j2
@@ -19,12 +19,12 @@ grafana:
     tls:
       enabled: {% if use_https == "yes" %}true{% else %}false{% endif %}
 {% if dex.enabled == true %}
-  annotations:
-    nginx.ingress.kubernetes.io/auth-signin: https://auth.{{ cluster_name }}/oauth2/start?rd=https://$host$request_uri$is_args$args
-    nginx.ingress.kubernetes.io/auth-url: http://oauth2-proxy.kube-system.svc.cluster.local:4180/oauth2/auth
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      auth_request_set $token $upstream_http_authorization;
-      proxy_set_header Authorization $token;
+    annotations:
+      nginx.ingress.kubernetes.io/auth-signin: https://auth.{{ cluster_name }}/oauth2/start?rd=https://$host$request_uri$is_args$args
+      nginx.ingress.kubernetes.io/auth-url: http://oauth2-proxy.kube-system.svc.cluster.local:4180/oauth2/auth
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        auth_request_set $token $upstream_http_authorization;
+        proxy_set_header Authorization $token;
 {% endif %}
 
 edge:


### PR DESCRIPTION
This PR enables Dex auth on enclave grafana when dex is enabled