### PR TITLE
[#247] fix airflow deploy default values

### DIFF
--- a/deploy/helms/airflow/values.yaml
+++ b/deploy/helms/airflow/values.yaml
@@ -75,7 +75,7 @@ webserver:
 
   dex_group_profiler: ~
 
-  dex_admin_email: test@legion.com
+  dex_admin_email: tests@legion.com
 
 smtp:
   smtp_host: localhost

--- a/deploy/helms/airflow/values.yaml
+++ b/deploy/helms/airflow/values.yaml
@@ -75,7 +75,7 @@ webserver:
 
   dex_group_profiler: ~
 
-  dex_admin_email: admin@example.com
+  dex_admin_email: test@legion.com
 
 smtp:
   smtp_host: localhost


### PR DESCRIPTION
Changed  "dex_admin_email" parameter from "admin@example.com" to "tests@legion.com" for working tests.