### PR TITLE
[#269] Request size limit in Flask is increased

### DIFF
--- a/deploy/ansible/roles/k8s_resources/templates/ingress-aws.yml.j2
+++ b/deploy/ansible/roles/k8s_resources/templates/ingress-aws.yml.j2
@@ -37,4 +37,5 @@ metadata:
   labels:
     app: ingress-nginx
 data:
+  proxy-body-size: 100m
   use-proxy-protocol: "true"

--- a/legion/legion/serving/config_default.py
+++ b/legion/legion/serving/config_default.py
@@ -18,6 +18,8 @@
 Default config for legion
 """
 
+MAX_CONTENT_LENGTH = 1024*1024*100  # limit request size to 100MB
+
 MODEL_ID = "dummy-model"
 
 LEGION_ADDR = "0.0.0.0"


### PR DESCRIPTION
#269 
Request size limit was increased to 100MB. According to a bug, there were problem with 20MB request.