### PR TITLE
[#277] Increased Airflow web probes timeout to 2 secs

### DIFF
--- a/deploy/helms/airflow/templates/web.yaml
+++ b/deploy/helms/airflow/templates/web.yaml
@@ -75,12 +75,14 @@ spec:
             port: 8080
           initialDelaySeconds: 60
           periodSeconds: 3
+          timeoutSeconds: 2
         readinessProbe:
           httpGet:
             path: /admin/rest_api/api?api=version
             port: 8080
           initialDelaySeconds: 60
           periodSeconds: 5
+          timeoutSeconds: 2
       volumes:
       - name: airflow-config-dir
         configMap:


### PR DESCRIPTION
#277 
Airflow Web pod slows down due to a number of DAGs. LivenessProbe is unable to get response in specified timeout. Thus Airflow Web is unavailable.