### PR TITLE
[#379] Fixes incorrect auth urls for components security check

### DIFF
--- a/legion_test/legion_test/robot/utils.py
+++ b/legion_test/legion_test/robot/utils.py
@@ -167,26 +167,27 @@ class Utils:
             raise Exception('Unexpected case happen!')
 
     @staticmethod
-    def get_component_auth_page(url):
+    def get_component_auth_page(url, jenkins=False):
         """
         Get component main auth page
 
-        :param url: component url
-        :type url: str
+        :param boolean jenkins: if jenkins service is under test
+        :param str url: component url
         :return:  response_code and response_text
         :rtype: dict
         """
-        if "jenkins" in url:
+        if jenkins:
             response = requests.get('{}/securityRealm/commenceLogin'.format(url), timeout=10)
         else:
             response = requests.get(url, timeout=10)
         return {"response_code": response.status_code, "response_text": response.text}
 
     @staticmethod
-    def post_credentials_to_auth(component_url, cluster_host, creds):
+    def post_credentials_to_auth(component_url, cluster_host, creds, jenkins=False):
         """
         Get session id and send post request with credentials to authorize
 
+        :param boolean jenkins: if jenkins service is under test
         :param str component_url: legion core component url
         :param str cluster_host: cluster host name
         :param dict creds: dict with login and password
@@ -197,7 +198,7 @@ class Utils:
         import re
 
         session = requests.Session()
-        if "jenkins" in component_url:
+        if jenkins:
             response = session.get("{}.{}/securityRealm/commenceLogin".format(component_url, cluster_host))
         else:
             response = session.get("{}.{}".format(component_url, cluster_host))

--- a/legion_test/legion_test/robot/utils.py
+++ b/legion_test/legion_test/robot/utils.py
@@ -176,13 +176,16 @@ class Utils:
         :return:  response_code and response_text
         :rtype: dict
         """
-        response = requests.get(url, timeout=10)
+        if "jenkins" in url:
+            response = requests.get('{}/securityRealm/commenceLogin'.format(url), timeout=10)
+        else:
+            response = requests.get(url, timeout=10)
         return {"response_code": response.status_code, "response_text": response.text}
 
     @staticmethod
     def post_credentials_to_auth(component_url, cluster_host, creds):
         """
-        Send post request with credentials to authorize
+        Get session id and send post request with credentials to authorize
 
         :param str component_url: legion core component url
         :param str cluster_host: cluster host name
@@ -194,7 +197,11 @@ class Utils:
         import re
 
         session = requests.Session()
-        response = session.get("{}.{}/securityRealm/commenceLogin".format(component_url, cluster_host))
+        if "jenkins" in component_url:
+            response = session.get("{}.{}/securityRealm/commenceLogin".format(component_url, cluster_host))
+        else:
+            response = session.get("{}.{}".format(component_url, cluster_host))
+
         if response.status_code != 200:
             raise IOError('Authentication endpoint is unavailable, got {} http code'
                           .format(response.status_code))
@@ -208,8 +215,7 @@ class Utils:
         if creds["login"] == "admin":
             response = session.post(AUTHENTICATION_PATH.format(cluster_host, request_id), creds)
         else:
-            session.post(AUTHENTICATION_PATH.format(cluster_host, request_id), creds)
-            response = session.get("{}.{}".format(component_url, cluster_host))
+            response = session.post(AUTHENTICATION_PATH.format(cluster_host, request_id), creds)
         return {"response_code": response.status_code, "response_text": response.text}
 
     @staticmethod

--- a/tests/robot/resources/keywords.robot
+++ b/tests/robot/resources/keywords.robot
@@ -222,8 +222,11 @@ Run, wait and check jenkins jobs for enclave
 Check if component domain has been secured
     [Arguments]     ${component}    ${enclave}
     [Documentation]  Check that a legion component is secured by auth
-    &{response} =    Run Keyword If   '${enclave}' == '${EMPTY}'    Get component auth page    ${HOST_PROTOCOL}://${component}.${HOST_BASE_DOMAIN}
-    ...    ELSE      Get component auth page    ${HOST_PROTOCOL}://${component}-${enclave}.${HOST_BASE_DOMAIN}
+    ${jenkins} =     Run Keyword If   '${component}' == 'jenkins'    Set Variable    True
+    ...    ELSE      Set Variable    False
+    ${boolean} =     Convert To Boolean    ${jenkins}
+    &{response} =    Run Keyword If   '${enclave}' == '${EMPTY}'    Get component auth page    ${HOST_PROTOCOL}://${component}.${HOST_BASE_DOMAIN}    ${boolean}
+    ...    ELSE      Get component auth page    ${HOST_PROTOCOL}://${component}-${enclave}.${HOST_BASE_DOMAIN}    ${boolean}
     Log              Auth page for ${component} is ${response}
     Dictionary Should Contain Item    ${response}    response_code    200
     ${auth_page} =   Get From Dictionary   ${response}    response_text
@@ -233,9 +236,12 @@ Check if component domain has been secured
 Secured component domain should not be accessible by invalid credentials
     [Arguments]     ${component}    ${enclave}
     [Documentation]  Check that a secured legion component does not provide access by invalid credentials
+    ${jenkins} =     Run Keyword If   '${component}' == 'jenkins'    Set Variable    True
+    ...    ELSE      Set Variable    False
+    ${boolean} =     Convert To Boolean    ${jenkins}
     &{creds} =       Create Dictionary 	login=admin   password=admin
-    &{response} =    Run Keyword If   '${enclave}' == '${EMPTY}'    Post credentials to auth    ${HOST_PROTOCOL}://${component}    ${HOST_BASE_DOMAIN}    ${creds}
-    ...    ELSE      Post credentials to auth    ${HOST_PROTOCOL}://${component}-${enclave}     ${HOST_BASE_DOMAIN}    ${creds}
+    &{response} =    Run Keyword If   '${enclave}' == '${EMPTY}'    Post credentials to auth    ${HOST_PROTOCOL}://${component}    ${HOST_BASE_DOMAIN}    ${creds}    ${boolean}
+    ...    ELSE      Post credentials to auth    ${HOST_PROTOCOL}://${component}-${enclave}     ${HOST_BASE_DOMAIN}    ${creds}    ${boolean}
     Log              Bad auth page for ${component} is ${response}
     Dictionary Should Contain Item    ${response}    response_code    200
     ${auth_page} =   Get From Dictionary   ${response}    response_text
@@ -246,9 +252,12 @@ Secured component domain should not be accessible by invalid credentials
 Secured component domain should be accessible by valid credentials
     [Arguments]     ${component}    ${enclave}
     [Documentation]  Check that a secured legion component does not provide access by invalid credentials
+    ${jenkins} =     Run Keyword If   '${component}' == 'jenkins'    Set Variable    True
+    ...    ELSE      Set Variable    False
+    ${boolean} =     Convert To Boolean    ${jenkins}
     &{creds} =       Get static user data
-    &{response} =    Run Keyword If   '${enclave}' == '${EMPTY}'    Post credentials to auth    ${HOST_PROTOCOL}://${component}    ${HOST_BASE_DOMAIN}    ${creds}
-    ...    ELSE      Post credentials to auth    ${HOST_PROTOCOL}://${component}-${enclave}     ${HOST_BASE_DOMAIN}    ${creds}
+    &{response} =    Run Keyword If   '${enclave}' == '${EMPTY}'    Post credentials to auth    ${HOST_PROTOCOL}://${component}    ${HOST_BASE_DOMAIN}    ${creds}    ${boolean}
+    ...    ELSE      Post credentials to auth    ${HOST_PROTOCOL}://${component}-${enclave}     ${HOST_BASE_DOMAIN}    ${creds}    ${boolean}
     Log              Bad auth page for ${component} is ${response}
     Dictionary Should Contain Item    ${response}    response_code    200
     ${auth_page} =   Get From Dictionary   ${response}    response_text

--- a/tests/robot/resources/keywords.robot
+++ b/tests/robot/resources/keywords.robot
@@ -222,8 +222,8 @@ Run, wait and check jenkins jobs for enclave
 Check if component domain has been secured
     [Arguments]     ${component}    ${enclave}
     [Documentation]  Check that a legion component is secured by auth
-    &{response} =    Run Keyword If   '${enclave}' == '${EMPTY}'    Get component auth page    ${HOST_PROTOCOL}://${component}.${HOST_BASE_DOMAIN}/securityRealm/commenceLogin?from=/
-    ...    ELSE      Get component auth page    ${HOST_PROTOCOL}://${component}-${enclave}.${HOST_BASE_DOMAIN}/securityRealm/commenceLogin?from=/
+    &{response} =    Run Keyword If   '${enclave}' == '${EMPTY}'    Get component auth page    ${HOST_PROTOCOL}://${component}.${HOST_BASE_DOMAIN}
+    ...    ELSE      Get component auth page    ${HOST_PROTOCOL}://${component}-${enclave}.${HOST_BASE_DOMAIN}
     Log              Auth page for ${component} is ${response}
     Dictionary Should Contain Item    ${response}    response_code    200
     ${auth_page} =   Get From Dictionary   ${response}    response_text


### PR DESCRIPTION
'/securityRealm/commenceLogin' postfix should be used only for the Jenkins component, and be removed from the verification from the other components.

This closes #379 