### PR TITLE
[#382] Add retries to legionctl tool

### DIFF
--- a/legion/legion/edi/server.py
+++ b/legion/legion/edi/server.py
@@ -133,7 +133,8 @@ def deploy(image, count=1, livenesstimeout=2, readinesstimeout=2):
 
     if image in deployed_models_by_image.keys():  # if model already deployed - return its deployment information
         LOGGER.info('Same model already has been deployed - skipping')
-        model_deployment = deployed_models_by_image[image]
+        model_service = deployed_models_by_image[image]
+        model_deployment = legion.k8s.ModelDeploymentDescription.build_from_model_service(model_service)
     else:
         model_service = app.config['ENCLAVE'].deploy_model(image, count, livenesstimeout, readinesstimeout)
         LOGGER.info('Model (id={}, version={}) has been deployed'

--- a/legion/legion/k8s/enclave.py
+++ b/legion/legion/k8s/enclave.py
@@ -179,14 +179,14 @@ class Enclave:
                 models[model_service.id_and_version] = model_service
         return models
 
-    def get_models(self, model_id, model_version=None):
+    def get_models(self, model_id=None, model_version=None):
         """
         Get models that fit match criterions (model id and model version, model id may be *, model version may be *)
 
         :param model_id: model id or */None for all models
-        :type model_id: str
+        :type model_id: str or None
         :param model_version: (Optional) model version or */None for all
-        :type model_version: str
+        :type model_version: str or None
         :return: list[:py:class:`legion.k8s.ModelService`] -- founded model services
         """
         return [

--- a/tests/robot/4_check_edi.robot
+++ b/tests/robot/4_check_edi.robot
@@ -83,8 +83,9 @@ Check EDI double deploy procedure for the same model
     ${response}=    Check model started           ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    ${TEST_MODEL_1_VERSION}
                     Should contain                ${response}             "model_version": "${TEST_MODEL_1_VERSION}"
     ${resp}=        Run EDI deploy                ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_IMAGE_1}
-                    Should Be Equal As Integers   ${resp.rc}         2
-                    Should Contain                ${resp.stderr}     Duplicating model id and version (id=${TEST_MODEL_ID}, version=${TEST_MODEL_1_VERSION})
+                    Should Be Equal As Integers   ${resp.rc}         0
+    ${response}=    Check model started           ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    ${TEST_MODEL_1_VERSION}
+                    Should contain                ${response}             "model_version": "${TEST_MODEL_1_VERSION}"
 
 Check EDI undeploy procedure
     [Documentation]  Try to undeploy dummy valid model through EDI console


### PR DESCRIPTION
This closes #382: PR adds retries for legionctl -> edi requests and adds analyzing current deployments on scale procedure