### PR TITLE
[#399] Add detailed legionctl logs

### DIFF
--- a/legion/bin/legionctl
+++ b/legion/bin/legionctl
@@ -143,7 +143,9 @@ if __name__ == '__main__':
     else:
         log_level = logging.ERROR
 
-    logging.basicConfig(level=log_level, format='%(asctime)s - %(levelname)s - %(message)s')
+    logging.basicConfig(level=log_level, 
+                        format='%(asctime)s - %(levelname)s - %(message)s',
+                        stream=sys.stderr)
 
     try:
         if 'func' in v:

--- a/legion/legion/edi/deploy.py
+++ b/legion/legion/edi/deploy.py
@@ -208,7 +208,7 @@ def wait_operation_finish(args, edi_client, model_deployments, wait_callback):
             LOGGER.info('Requesting actual status of affected deployments')
             affected_deployments_status = get_related_model_deployments(edi_client, model_deployments)
             LOGGER.debug('Server returned list of actual affected deployment statuses: {!r}'
-                        .format(affected_deployments_status))
+                         .format(affected_deployments_status))
 
             result = wait_callback(affected_deployments_status)
             if result:

--- a/legion/legion/external/edi.py
+++ b/legion/legion/external/edi.py
@@ -82,11 +82,10 @@ class EdiClient:
         except requests.exceptions.ConnectionError as exception:
             raise Exception('Failed to connect to {}: {}'.format(self._base, exception))
 
-        LOGGER.debug('Got answer: {!r} with code {} for URL {!r}'
-                     .format(response.text, response.status_code, full_url))
-
         try:
             answer = json.loads(response.text)
+            LOGGER.debug('Got answer: {!r} with code {} for URL {!r}'
+                        .format(answer, response.status_code, full_url))
         except ValueError as json_decode_exception:
             raise ValueError('Invalid JSON structure {!r}: {}'.format(response.text, json_decode_exception))
 
@@ -209,6 +208,16 @@ class EdiClient:
             payload['version'] = version
 
         return self.parse_deployments(self._query(legion.edi.server.EDI_SCALE, action='POST', payload=payload))
+
+    def __repr__(self):
+        """
+        Get string representation of object
+        
+        :return: str -- string representation
+        """
+        return "EdiClient({!r})".format(self._base)
+
+    __str__ = __repr__
 
 
 def add_edi_arguments(parser):

--- a/legion/legion/external/edi.py
+++ b/legion/legion/external/edi.py
@@ -85,7 +85,7 @@ class EdiClient:
         try:
             answer = json.loads(response.text)
             LOGGER.debug('Got answer: {!r} with code {} for URL {!r}'
-                        .format(answer, response.status_code, full_url))
+                         .format(answer, response.status_code, full_url))
         except ValueError as json_decode_exception:
             raise ValueError('Invalid JSON structure {!r}: {}'.format(response.text, json_decode_exception))
 
@@ -212,7 +212,7 @@ class EdiClient:
     def __repr__(self):
         """
         Get string representation of object
-        
+
         :return: str -- string representation
         """
         return "EdiClient({!r})".format(self._base)

--- a/legion/legion/external/edi.py
+++ b/legion/legion/external/edi.py
@@ -107,7 +107,7 @@ class EdiClient:
         :type response: list[dict[str, any]]
         :return: list[:py:class:`legion.k8s.ModelDeploymentDescription`] -- parsed model deployments
         """
-        return [legion.k8s.ModelDeploymentDescription(**x) for x in response]
+        return [legion.k8s.ModelDeploymentDescription.build_from_json(x) for x in response]
 
     def inspect(self, model=None, version=None):
         """

--- a/legion/legion/k8s/definitions.py
+++ b/legion/legion/k8s/definitions.py
@@ -292,3 +292,18 @@ class ModelDeploymentDescription:
             'model_api_ok': self._model_api_ok,
             'model_api_info': self._model_api_info
         }
+
+    def __repr__(self):
+        """
+        Get string representation of object
+        
+        :return: str -- string representation
+        """
+        args = ",".join(repr(arg) for arg in [
+            self.status, self.model, self.version, self.image, 
+            self.scale, self.ready_replicas, self.namespace, 
+            self.model_api_ok, self.model_api_info
+        ])
+        return "ModelDeploymentDescription({})".format(args)
+
+    __str__ = __repr__

--- a/legion/legion/k8s/definitions.py
+++ b/legion/legion/k8s/definitions.py
@@ -297,8 +297,8 @@ class ModelDeploymentDescription:
     def build_from_json(json_dict):
         """
         Build ModelDeploymentDescription from JSON dict
-        
-        :param json_dict: result of deserialization serialized .as_dict response 
+
+        :param json_dict: result of deserialization serialized .as_dict response
         :type json_dict: dict[str, Any]
         :return: :py:class:`legion.k8s.definitions.ModelDeploymentDescription` -- built model deployment
         """
@@ -309,12 +309,12 @@ class ModelDeploymentDescription:
     def __repr__(self):
         """
         Get string representation of object
-        
+
         :return: str -- string representation
         """
         args = ",".join(repr(arg) for arg in [
-            self.status, self.model, self.version, self.image, 
-            self.scale, self.ready_replicas, self.namespace, 
+            self.status, self.model, self.version, self.image,
+            self.scale, self.ready_replicas, self.namespace,
             self.model_api_ok, self.model_api_info
         ])
         return "ModelDeploymentDescription({})".format(args)

--- a/legion/legion/k8s/definitions.py
+++ b/legion/legion/k8s/definitions.py
@@ -171,7 +171,7 @@ class ModelDeploymentDescription:
         :type model_api_ok: bool or None
         :param model_api_info: (Optional) model API info from EDGE invocation
         :type model_api_info: dict or None
-        :return: :py:class:`legion.k8s.definitions.ModelDeploymentDescription` -- build model deployment
+        :return: :py:class:`legion.k8s.definitions.ModelDeploymentDescription` -- built model deployment
         """
         return ModelDeploymentDescription(
             status=model_service.status,
@@ -292,6 +292,19 @@ class ModelDeploymentDescription:
             'model_api_ok': self._model_api_ok,
             'model_api_info': self._model_api_info
         }
+
+    @staticmethod
+    def build_from_json(json_dict):
+        """
+        Build ModelDeploymentDescription from JSON dict
+        
+        :param json_dict: result of deserialization serialized .as_dict response 
+        :type json_dict: dict[str, Any]
+        :return: :py:class:`legion.k8s.definitions.ModelDeploymentDescription` -- built model deployment
+        """
+        if isinstance(json_dict['model_api_info'], bytes):
+            json_dict['model_api_info'] = json.loads(json_dict['model_api_info'])
+        return ModelDeploymentDescription(**json_dict)
 
     def __repr__(self):
         """

--- a/tests/robot/resources/keywords.robot
+++ b/tests/robot/resources/keywords.robot
@@ -30,7 +30,7 @@ Connect to enclave Flower
 Run EDI inspect enclave and check result
     [Documentation]  run legionctl 'inspect command', logs result and return dict with return code and output
     [Arguments]           ${enclave}    ${expected_rc}   ${expected_output}
-    ${result}=            Run Process   legionctl inspect --format column --edi ${HOST_PROTOCOL}://edi-${enclave}.${HOST_BASE_DOMAIN} --user ${SERVICE_ACCOUNT} --password ${SERVICE_PASSWORD}    shell=True
+    ${result}=            Run Process   legionctl --verbose inspect --format column --edi ${HOST_PROTOCOL}://edi-${enclave}.${HOST_BASE_DOMAIN} --user ${SERVICE_ACCOUNT} --password ${SERVICE_PASSWORD}    shell=True
     Log                   stdout = ${result.stdout}
     Log                   stderr = ${result.stdout}
     Should Be Equal As Integers  ${result.rc}        ${expected_rc}
@@ -39,7 +39,7 @@ Run EDI inspect enclave and check result
 Run EDI inspect
     [Documentation]  run legionctl 'inspect command', logs result and return dict with return code and output
     [Arguments]           ${enclave}
-    ${result}=            Run Process   legionctl inspect --format column --edi ${HOST_PROTOCOL}://edi-${enclave}.${HOST_BASE_DOMAIN} --user ${SERVICE_ACCOUNT} --password ${SERVICE_PASSWORD}    shell=True
+    ${result}=            Run Process   legionctl --verbose inspect --format column --edi ${HOST_PROTOCOL}://edi-${enclave}.${HOST_BASE_DOMAIN} --user ${SERVICE_ACCOUNT} --password ${SERVICE_PASSWORD}    shell=True
     Log                   stdout = ${result.stdout}
     Log                   stderr = ${result.stderr}
     [Return]              ${result}
@@ -47,7 +47,7 @@ Run EDI inspect
 Run EDI inspect by model id
     [Documentation]  run legionctl 'inspect command', logs result and return dict with return code and output
     [Arguments]           ${enclave}    ${model_id}
-    ${result}=            Run Process   legionctl inspect --model-id ${model_id} --format column --edi ${HOST_PROTOCOL}://edi-${enclave}.${HOST_BASE_DOMAIN} --user ${SERVICE_ACCOUNT} --password ${SERVICE_PASSWORD}    shell=True
+    ${result}=            Run Process   legionctl --verbose inspect --model-id ${model_id} --format column --edi ${HOST_PROTOCOL}://edi-${enclave}.${HOST_BASE_DOMAIN} --user ${SERVICE_ACCOUNT} --password ${SERVICE_PASSWORD}    shell=True
     Log                   stdout = ${result.stdout}
     Log                   stderr = ${result.stderr}
     [Return]              ${result}
@@ -55,7 +55,7 @@ Run EDI inspect by model id
 Run EDI inspect by model version
     [Documentation]  run legionctl 'inspect command', logs result and return dict with return code and output
     [Arguments]           ${enclave}    ${model_ver}
-    ${result}=            Run Process   legionctl inspect --model-version ${model_ver} --format column --edi ${HOST_PROTOCOL}://edi-${enclave}.${HOST_BASE_DOMAIN} --user ${SERVICE_ACCOUNT} --password ${SERVICE_PASSWORD}    shell=True
+    ${result}=            Run Process   legionctl --verbose inspect --model-version ${model_ver} --format column --edi ${HOST_PROTOCOL}://edi-${enclave}.${HOST_BASE_DOMAIN} --user ${SERVICE_ACCOUNT} --password ${SERVICE_PASSWORD}    shell=True
     Log                   stdout = ${result.stdout}
     Log                   stderr = ${result.stderr}
     [Return]              ${result}
@@ -63,7 +63,7 @@ Run EDI inspect by model version
 Run EDI inspect by model id and model version
     [Documentation]  run legionctl 'inspect command', logs result and return dict with return code and output
     [Arguments]           ${enclave}    ${model_id}     ${model_ver}
-    ${result}=            Run Process   legionctl inspect --model-id ${model_id} --model-version ${model_ver} --format column --edi ${HOST_PROTOCOL}://edi-${enclave}.${HOST_BASE_DOMAIN} --user ${SERVICE_ACCOUNT} --password ${SERVICE_PASSWORD}    shell=True
+    ${result}=            Run Process   legionctl --verbose inspect --model-id ${model_id} --model-version ${model_ver} --format column --edi ${HOST_PROTOCOL}://edi-${enclave}.${HOST_BASE_DOMAIN} --user ${SERVICE_ACCOUNT} --password ${SERVICE_PASSWORD}    shell=True
     Log                   stdout = ${result.stdout}
     Log                   stderr = ${result.stderr}
     [Return]              ${result}
@@ -88,7 +88,7 @@ Run EDI inspect with parse by model id
 Run EDI deploy
     [Documentation]  run legionctl 'deploy command', logs result and return dict with return code and output(for exceptions)
     [Arguments]           ${enclave}    ${image}
-    ${result}=            Run Process   legionctl deploy ${image} --edi ${HOST_PROTOCOL}://edi-${enclave}.${HOST_BASE_DOMAIN} --user ${SERVICE_ACCOUNT} --password ${SERVICE_PASSWORD}    shell=True
+    ${result}=            Run Process   legionctl --verbose deploy ${image} --edi ${HOST_PROTOCOL}://edi-${enclave}.${HOST_BASE_DOMAIN} --user ${SERVICE_ACCOUNT} --password ${SERVICE_PASSWORD}    shell=True
     Log                   stdout = ${result.stdout}
     Log                   stderr = ${result.stderr}
     [Return]              ${result}
@@ -96,7 +96,7 @@ Run EDI deploy
 Run EDI deploy with scale
     [Documentation]  run legionctl 'deploy command with scale option', logs result and return dict with return code and output(for exceptions)
     [Arguments]           ${enclave}    ${image}    ${scale_count}
-    ${result}=            Run Process   legionctl deploy ${image} --scale ${scale_count} --edi ${HOST_PROTOCOL}://edi-${enclave}.${HOST_BASE_DOMAIN} --user ${SERVICE_ACCOUNT} --password ${SERVICE_PASSWORD}    shell=True
+    ${result}=            Run Process   legionctl --verbose deploy ${image} --scale ${scale_count} --edi ${HOST_PROTOCOL}://edi-${enclave}.${HOST_BASE_DOMAIN} --user ${SERVICE_ACCOUNT} --password ${SERVICE_PASSWORD}    shell=True
     Log                   stdout = ${result.stdout}
     Log                   stderr = ${result.stderr}
     [Return]              ${result}
@@ -129,7 +129,7 @@ Run EDI undeploy model without version and check
 
 Run EDI undeploy with version
     [Arguments]           ${enclave}    ${model_id}  ${model_version}
-    ${result}=            Run Process   legionctl undeploy ${model_id} --model-version ${model_version} --ignore-not-found --edi ${HOST_PROTOCOL}://edi-${enclave}.${HOST_BASE_DOMAIN} --user ${SERVICE_ACCOUNT} --password ${SERVICE_PASSWORD}     shell=True
+    ${result}=            Run Process   legionctl --verbose undeploy ${model_id} --model-version ${model_version} --ignore-not-found --edi ${HOST_PROTOCOL}://edi-${enclave}.${HOST_BASE_DOMAIN} --user ${SERVICE_ACCOUNT} --password ${SERVICE_PASSWORD}     shell=True
     Log                   stdout = ${result.stdout}
     Log                   stderr = ${result.stderr}
     [Return]              ${result}
@@ -137,7 +137,7 @@ Run EDI undeploy with version
 Run EDI undeploy without version
     [Documentation]  run legionctl 'undeploy command', logs result and return dict with return code and output(for exceptions)
     [Arguments]           ${enclave}    ${model_id}
-    ${result}=            Run Process   legionctl undeploy ${model_id} --ignore-not-found --edi ${HOST_PROTOCOL}://edi-${enclave}.${HOST_BASE_DOMAIN} --user ${SERVICE_ACCOUNT} --password ${SERVICE_PASSWORD}    shell=True
+    ${result}=            Run Process   legionctl --verbose undeploy ${model_id} --ignore-not-found --edi ${HOST_PROTOCOL}://edi-${enclave}.${HOST_BASE_DOMAIN} --user ${SERVICE_ACCOUNT} --password ${SERVICE_PASSWORD}    shell=True
     Log                   stdout = ${result.stdout}
     Log                   stderr = ${result.stderr}
     [Return]              ${result}
@@ -146,7 +146,7 @@ Run EDI undeploy without version
 Run EDI scale
     [Documentation]  run legionctl 'scale command', logs result and return dict with return code and output(for exceptions)
     [Arguments]           ${enclave}    ${model_id}     ${new_scale}
-    ${result}=            Run Process   legionctl scale ${model_id} ${new_scale} --edi ${HOST_PROTOCOL}://edi-${enclave}.${HOST_BASE_DOMAIN} --user ${SERVICE_ACCOUNT} --password ${SERVICE_PASSWORD}   shell=True
+    ${result}=            Run Process   legionctl --verbose scale ${model_id} ${new_scale} --edi ${HOST_PROTOCOL}://edi-${enclave}.${HOST_BASE_DOMAIN} --user ${SERVICE_ACCOUNT} --password ${SERVICE_PASSWORD}   shell=True
     Log                   stdout = ${result.stdout}
     Log                   stderr = ${result.stderr}
     [Return]              ${result}
@@ -154,7 +154,7 @@ Run EDI scale
 Run EDI scale with version
     [Documentation]  run legionctl 'scale command', logs result and return dict with return code and output(for exceptions)
     [Arguments]           ${enclave}    ${model_id}     ${new_scale}    ${model_ver}
-    ${result}=            Run Process   legionctl scale ${model_id} ${new_scale} --model-version ${model_ver} --edi ${HOST_PROTOCOL}://edi-${enclave}.${HOST_BASE_DOMAIN} --user ${SERVICE_ACCOUNT} --password ${SERVICE_PASSWORD}    shell=True
+    ${result}=            Run Process   legionctl --verbose scale ${model_id} ${new_scale} --model-version ${model_ver} --edi ${HOST_PROTOCOL}://edi-${enclave}.${HOST_BASE_DOMAIN} --user ${SERVICE_ACCOUNT} --password ${SERVICE_PASSWORD}    shell=True
     Log                   stdout = ${result.stdout}
     Log                   stderr = ${result.stderr}
     [Return]              ${result}


### PR DESCRIPTION
This closes #399.
Example:
```
legionctl --verbose scale test-summation 5 --edi https://edi-company-a.legion-dev.epm.kharlamov.biz
2018-08-30 20:35:15,036 - INFO - Sending scale request to EdiClient('https://edi-company-a.legion-dev.epm.kharlamov.biz')
2018-08-30 20:35:15,038 - DEBUG - Starting new HTTPS connection (1): edi-company-a.legion-dev.epm.kharlamov.biz
2018-08-30 20:35:17,104 - DEBUG - https://edi-company-a.legion-dev.epm.kharlamov.biz:443 "POST /api/1.0/scale HTTP/1.1" 200 None
2018-08-30 20:35:17,105 - DEBUG - Got answer: [{'image': 'localhost:31111/legion_model/test-summation:1.0-180830135752.2.8f237a9', 'model': 'test-summation', 'model_api_info': None, 'model_api_ok': None, 'namespace': 'company-a', 'ready_replicas': 1, 'scale': 1, 'status': 'ok', 'version': '1.0'}] with code 200 for URL 'https://edi-company-a.legion-dev.epm.kharlamov.biz/api/1.0/scale'
2018-08-30 20:35:17,105 - INFO - Server returned list of affected deployments: [ModelDeploymentDescription('ok','test-summation','1.0','localhost:31111/legion_model/test-summation:1.0-180830135752.2.8f237a9',1,1,'company-a',None,None)]
2018-08-30 20:35:17,105 - DEBUG - Starting checking cycle limited to 120 s.
2018-08-30 20:35:17,105 - INFO - Requesting actual status of affected deployments
2018-08-30 20:35:17,107 - DEBUG - Starting new HTTPS connection (1): edi-company-a.legion-dev.epm.kharlamov.biz
2018-08-30 20:35:18,959 - DEBUG - https://edi-company-a.legion-dev.epm.kharlamov.biz:443 "GET /api/1.0/inspect HTTP/1.1" 200 None
2018-08-30 20:35:18,965 - DEBUG - Got answer: [{'image': 'localhost:31111/legion_model/recognize-digits:1.0-180830135358.1.8f237a9', 'model': 'recognize-digits', 'model_api_info': {'result': {'endpoints': {'default': {'input_params': {'image': {'numpy_type': 'object', 'type': 'Image'}}, 'name': 'default', 'use_df': False}}, 'model_id': 'recognize-digits', 'model_version': '1.0'}}, 'model_api_ok': True, 'namespace': 'company-a', 'ready_replicas': 1, 'scale': 1, 'status': 'ok', 'version': '1.0'}, {'image': 'localhost:31111/legion_model/test-summation:1.0-180830135752.2.8f237a9', 'model': 'test-summation', 'model_api_info': {'result': {'endpoints': {'default': {'input_params': False, 'name': 'default', 'use_df': False}, 'sum_and_pow': {'input_params': {'a': {'numpy_type': 'int32', 'type': 'Integer'}, 'b': {'numpy_type': 'int32', 'type': 'Integer'}}, 'name': 'sum_and_pow', 'use_df': False}}, 'model_id': 'test-summation', 'model_version': '1.0'}}, 'model_api_ok': True, 'namespace': 'company-a', 'ready_replicas': 1, 'scale': 5, 'status': 'warning', 'version': '1.0'}] with code 200 for URL 'https://edi-company-a.legion-dev.epm.kharlamov.biz/api/1.0/inspect'
2018-08-30 20:35:18,966 - DEBUG - Server returned list of actual affected deployment statuses: [ModelDeploymentDescription('warning','test-summation','1.0','localhost:31111/legion_model/test-summation:1.0-180830135752.2.8f237a9',5,1,'company-a',True,{'result': {'endpoints': {'default': {'input_params': False, 'name': 'default', 'use_df': False}, 'sum_and_pow': {'input_params': {'a': {'numpy_type': 'int32', 'type': 'Integer'}, 'b': {'numpy_type': 'int32', 'type': 'Integer'}}, 'name': 'sum_and_pow', 'use_df': False}}, 'model_id': 'test-summation', 'model_version': '1.0'}})]
2018-08-30 20:35:18,966 - INFO - Callback have not confirmed completion of the operation
2018-08-30 20:35:18,966 - DEBUG - Sleep before next request
2018-08-30 20:35:19,967 - INFO - Requesting actual status of affected deployments
2018-08-30 20:35:19,972 - DEBUG - Starting new HTTPS connection (1): edi-company-a.legion-dev.epm.kharlamov.biz
2018-08-30 20:35:21,683 - DEBUG - https://edi-company-a.legion-dev.epm.kharlamov.biz:443 "GET /api/1.0/inspect HTTP/1.1" 200 None
2018-08-30 20:35:21,690 - DEBUG - Got answer: [{'image': 'localhost:31111/legion_model/recognize-digits:1.0-180830135358.1.8f237a9', 'model': 'recognize-digits', 'model_api_info': {'result': {'endpoints': {'default': {'input_params': {'image': {'numpy_type': 'object', 'type': 'Image'}}, 'name': 'default', 'use_df': False}}, 'model_id': 'recognize-digits', 'model_version': '1.0'}}, 'model_api_ok': True, 'namespace': 'company-a', 'ready_replicas': 1, 'scale': 1, 'status': 'ok', 'version': '1.0'}, {'image': 'localhost:31111/legion_model/test-summation:1.0-180830135752.2.8f237a9', 'model': 'test-summation', 'model_api_info': {'result': {'endpoints': {'default': {'input_params': False, 'name': 'default', 'use_df': False}, 'sum_and_pow': {'input_params': {'a': {'numpy_type': 'int32', 'type': 'Integer'}, 'b': {'numpy_type': 'int32', 'type': 'Integer'}}, 'name': 'sum_and_pow', 'use_df': False}}, 'model_id': 'test-summation', 'model_version': '1.0'}}, 'model_api_ok': True, 'namespace': 'company-a', 'ready_replicas': 1, 'scale': 5, 'status': 'warning', 'version': '1.0'}] with code 200 for URL 'https://edi-company-a.legion-dev.epm.kharlamov.biz/api/1.0/inspect'
2018-08-30 20:35:21,691 - DEBUG - Server returned list of actual affected deployment statuses: [ModelDeploymentDescription('warning','test-summation','1.0','localhost:31111/legion_model/test-summation:1.0-180830135752.2.8f237a9',5,1,'company-a',True,{'result': {'endpoints': {'default': {'input_params': False, 'name': 'default', 'use_df': False}, 'sum_and_pow': {'input_params': {'a': {'numpy_type': 'int32', 'type': 'Integer'}, 'b': {'numpy_type': 'int32', 'type': 'Integer'}}, 'name': 'sum_and_pow', 'use_df': False}}, 'model_id': 'test-summation', 'model_version': '1.0'}})]
2018-08-30 20:35:21,692 - INFO - Callback have not confirmed completion of the operation
2018-08-30 20:35:21,692 - DEBUG - Sleep before next request
2018-08-30 20:35:22,693 - INFO - Requesting actual status of affected deployments
2018-08-30 20:35:22,699 - DEBUG - Starting new HTTPS connection (1): edi-company-a.legion-dev.epm.kharlamov.biz
2018-08-30 20:35:24,455 - DEBUG - https://edi-company-a.legion-dev.epm.kharlamov.biz:443 "GET /api/1.0/inspect HTTP/1.1" 200 None
2018-08-30 20:35:24,461 - DEBUG - Got answer: [{'image': 'localhost:31111/legion_model/recognize-digits:1.0-180830135358.1.8f237a9', 'model': 'recognize-digits', 'model_api_info': {'result': {'endpoints': {'default': {'input_params': {'image': {'numpy_type': 'object', 'type': 'Image'}}, 'name': 'default', 'use_df': False}}, 'model_id': 'recognize-digits', 'model_version': '1.0'}}, 'model_api_ok': True, 'namespace': 'company-a', 'ready_replicas': 1, 'scale': 1, 'status': 'ok', 'version': '1.0'}, {'image': 'localhost:31111/legion_model/test-summation:1.0-180830135752.2.8f237a9', 'model': 'test-summation', 'model_api_info': {'result': {'endpoints': {'default': {'input_params': False, 'name': 'default', 'use_df': False}, 'sum_and_pow': {'input_params': {'a': {'numpy_type': 'int32', 'type': 'Integer'}, 'b': {'numpy_type': 'int32', 'type': 'Integer'}}, 'name': 'sum_and_pow', 'use_df': False}}, 'model_id': 'test-summation', 'model_version': '1.0'}}, 'model_api_ok': True, 'namespace': 'company-a', 'ready_replicas': 1, 'scale': 5, 'status': 'warning', 'version': '1.0'}] with code 200 for URL 'https://edi-company-a.legion-dev.epm.kharlamov.biz/api/1.0/inspect'
2018-08-30 20:35:24,461 - DEBUG - Server returned list of actual affected deployment statuses: [ModelDeploymentDescription('warning','test-summation','1.0','localhost:31111/legion_model/test-summation:1.0-180830135752.2.8f237a9',5,1,'company-a',True,{'result': {'endpoints': {'default': {'input_params': False, 'name': 'default', 'use_df': False}, 'sum_and_pow': {'input_params': {'a': {'numpy_type': 'int32', 'type': 'Integer'}, 'b': {'numpy_type': 'int32', 'type': 'Integer'}}, 'name': 'sum_and_pow', 'use_df': False}}, 'model_id': 'test-summation', 'model_version': '1.0'}})]
2018-08-30 20:35:24,462 - INFO - Callback have not confirmed completion of the operation
2018-08-30 20:35:24,462 - DEBUG - Sleep before next request
2018-08-30 20:35:25,463 - INFO - Requesting actual status of affected deployments
2018-08-30 20:35:25,468 - DEBUG - Starting new HTTPS connection (1): edi-company-a.legion-dev.epm.kharlamov.biz
2018-08-30 20:35:27,425 - DEBUG - https://edi-company-a.legion-dev.epm.kharlamov.biz:443 "GET /api/1.0/inspect HTTP/1.1" 200 None
2018-08-30 20:35:27,431 - DEBUG - Got answer: [{'image': 'localhost:31111/legion_model/recognize-digits:1.0-180830135358.1.8f237a9', 'model': 'recognize-digits', 'model_api_info': {'result': {'endpoints': {'default': {'input_params': {'image': {'numpy_type': 'object', 'type': 'Image'}}, 'name': 'default', 'use_df': False}}, 'model_id': 'recognize-digits', 'model_version': '1.0'}}, 'model_api_ok': True, 'namespace': 'company-a', 'ready_replicas': 1, 'scale': 1, 'status': 'ok', 'version': '1.0'}, {'image': 'localhost:31111/legion_model/test-summation:1.0-180830135752.2.8f237a9', 'model': 'test-summation', 'model_api_info': {'result': {'endpoints': {'default': {'input_params': False, 'name': 'default', 'use_df': False}, 'sum_and_pow': {'input_params': {'a': {'numpy_type': 'int32', 'type': 'Integer'}, 'b': {'numpy_type': 'int32', 'type': 'Integer'}}, 'name': 'sum_and_pow', 'use_df': False}}, 'model_id': 'test-summation', 'model_version': '1.0'}}, 'model_api_ok': True, 'namespace': 'company-a', 'ready_replicas': 1, 'scale': 5, 'status': 'warning', 'version': '1.0'}] with code 200 for URL 'https://edi-company-a.legion-dev.epm.kharlamov.biz/api/1.0/inspect'
2018-08-30 20:35:27,432 - DEBUG - Server returned list of actual affected deployment statuses: [ModelDeploymentDescription('warning','test-summation','1.0','localhost:31111/legion_model/test-summation:1.0-180830135752.2.8f237a9',5,1,'company-a',True,{'result': {'endpoints': {'default': {'input_params': False, 'name': 'default', 'use_df': False}, 'sum_and_pow': {'input_params': {'a': {'numpy_type': 'int32', 'type': 'Integer'}, 'b': {'numpy_type': 'int32', 'type': 'Integer'}}, 'name': 'sum_and_pow', 'use_df': False}}, 'model_id': 'test-summation', 'model_version': '1.0'}})]
2018-08-30 20:35:27,432 - INFO - Callback have not confirmed completion of the operation
2018-08-30 20:35:27,432 - DEBUG - Sleep before next request
2018-08-30 20:35:28,434 - INFO - Requesting actual status of affected deployments
2018-08-30 20:35:28,439 - DEBUG - Starting new HTTPS connection (1): edi-company-a.legion-dev.epm.kharlamov.biz
2018-08-30 20:35:30,081 - DEBUG - https://edi-company-a.legion-dev.epm.kharlamov.biz:443 "GET /api/1.0/inspect HTTP/1.1" 200 None
2018-08-30 20:35:30,086 - DEBUG - Got answer: [{'image': 'localhost:31111/legion_model/recognize-digits:1.0-180830135358.1.8f237a9', 'model': 'recognize-digits', 'model_api_info': {'result': {'endpoints': {'default': {'input_params': {'image': {'numpy_type': 'object', 'type': 'Image'}}, 'name': 'default', 'use_df': False}}, 'model_id': 'recognize-digits', 'model_version': '1.0'}}, 'model_api_ok': True, 'namespace': 'company-a', 'ready_replicas': 1, 'scale': 1, 'status': 'ok', 'version': '1.0'}, {'image': 'localhost:31111/legion_model/test-summation:1.0-180830135752.2.8f237a9', 'model': 'test-summation', 'model_api_info': {'result': {'endpoints': {'default': {'input_params': False, 'name': 'default', 'use_df': False}, 'sum_and_pow': {'input_params': {'a': {'numpy_type': 'int32', 'type': 'Integer'}, 'b': {'numpy_type': 'int32', 'type': 'Integer'}}, 'name': 'sum_and_pow', 'use_df': False}}, 'model_id': 'test-summation', 'model_version': '1.0'}}, 'model_api_ok': True, 'namespace': 'company-a', 'ready_replicas': 1, 'scale': 5, 'status': 'warning', 'version': '1.0'}] with code 200 for URL 'https://edi-company-a.legion-dev.epm.kharlamov.biz/api/1.0/inspect'
2018-08-30 20:35:30,086 - DEBUG - Server returned list of actual affected deployment statuses: [ModelDeploymentDescription('warning','test-summation','1.0','localhost:31111/legion_model/test-summation:1.0-180830135752.2.8f237a9',5,1,'company-a',True,{'result': {'endpoints': {'default': {'input_params': False, 'name': 'default', 'use_df': False}, 'sum_and_pow': {'input_params': {'a': {'numpy_type': 'int32', 'type': 'Integer'}, 'b': {'numpy_type': 'int32', 'type': 'Integer'}}, 'name': 'sum_and_pow', 'use_df': False}}, 'model_id': 'test-summation', 'model_version': '1.0'}})]
2018-08-30 20:35:30,086 - INFO - Callback have not confirmed completion of the operation
2018-08-30 20:35:30,086 - DEBUG - Sleep before next request
2018-08-30 20:35:31,087 - INFO - Requesting actual status of affected deployments
2018-08-30 20:35:31,092 - DEBUG - Starting new HTTPS connection (1): edi-company-a.legion-dev.epm.kharlamov.biz
2018-08-30 20:35:32,743 - DEBUG - https://edi-company-a.legion-dev.epm.kharlamov.biz:443 "GET /api/1.0/inspect HTTP/1.1" 200 None
2018-08-30 20:35:32,750 - DEBUG - Got answer: [{'image': 'localhost:31111/legion_model/recognize-digits:1.0-180830135358.1.8f237a9', 'model': 'recognize-digits', 'model_api_info': {'result': {'endpoints': {'default': {'input_params': {'image': {'numpy_type': 'object', 'type': 'Image'}}, 'name': 'default', 'use_df': False}}, 'model_id': 'recognize-digits', 'model_version': '1.0'}}, 'model_api_ok': True, 'namespace': 'company-a', 'ready_replicas': 1, 'scale': 1, 'status': 'ok', 'version': '1.0'}, {'image': 'localhost:31111/legion_model/test-summation:1.0-180830135752.2.8f237a9', 'model': 'test-summation', 'model_api_info': {'result': {'endpoints': {'default': {'input_params': False, 'name': 'default', 'use_df': False}, 'sum_and_pow': {'input_params': {'a': {'numpy_type': 'int32', 'type': 'Integer'}, 'b': {'numpy_type': 'int32', 'type': 'Integer'}}, 'name': 'sum_and_pow', 'use_df': False}}, 'model_id': 'test-summation', 'model_version': '1.0'}}, 'model_api_ok': True, 'namespace': 'company-a', 'ready_replicas': 1, 'scale': 5, 'status': 'warning', 'version': '1.0'}] with code 200 for URL 'https://edi-company-a.legion-dev.epm.kharlamov.biz/api/1.0/inspect'
2018-08-30 20:35:32,751 - DEBUG - Server returned list of actual affected deployment statuses: [ModelDeploymentDescription('warning','test-summation','1.0','localhost:31111/legion_model/test-summation:1.0-180830135752.2.8f237a9',5,1,'company-a',True,{'result': {'endpoints': {'default': {'input_params': False, 'name': 'default', 'use_df': False}, 'sum_and_pow': {'input_params': {'a': {'numpy_type': 'int32', 'type': 'Integer'}, 'b': {'numpy_type': 'int32', 'type': 'Integer'}}, 'name': 'sum_and_pow', 'use_df': False}}, 'model_id': 'test-summation', 'model_version': '1.0'}})]
2018-08-30 20:35:32,751 - INFO - Callback have not confirmed completion of the operation
2018-08-30 20:35:32,752 - DEBUG - Sleep before next request
2018-08-30 20:35:33,753 - INFO - Requesting actual status of affected deployments
2018-08-30 20:35:33,759 - DEBUG - Starting new HTTPS connection (1): edi-company-a.legion-dev.epm.kharlamov.biz
2018-08-30 20:35:35,455 - DEBUG - https://edi-company-a.legion-dev.epm.kharlamov.biz:443 "GET /api/1.0/inspect HTTP/1.1" 200 None
2018-08-30 20:35:35,461 - DEBUG - Got answer: [{'image': 'localhost:31111/legion_model/recognize-digits:1.0-180830135358.1.8f237a9', 'model': 'recognize-digits', 'model_api_info': {'result': {'endpoints': {'default': {'input_params': {'image': {'numpy_type': 'object', 'type': 'Image'}}, 'name': 'default', 'use_df': False}}, 'model_id': 'recognize-digits', 'model_version': '1.0'}}, 'model_api_ok': True, 'namespace': 'company-a', 'ready_replicas': 1, 'scale': 1, 'status': 'ok', 'version': '1.0'}, {'image': 'localhost:31111/legion_model/test-summation:1.0-180830135752.2.8f237a9', 'model': 'test-summation', 'model_api_info': {'result': {'endpoints': {'default': {'input_params': False, 'name': 'default', 'use_df': False}, 'sum_and_pow': {'input_params': {'a': {'numpy_type': 'int32', 'type': 'Integer'}, 'b': {'numpy_type': 'int32', 'type': 'Integer'}}, 'name': 'sum_and_pow', 'use_df': False}}, 'model_id': 'test-summation', 'model_version': '1.0'}}, 'model_api_ok': True, 'namespace': 'company-a', 'ready_replicas': 2, 'scale': 5, 'status': 'warning', 'version': '1.0'}] with code 200 for URL 'https://edi-company-a.legion-dev.epm.kharlamov.biz/api/1.0/inspect'
2018-08-30 20:35:35,462 - DEBUG - Server returned list of actual affected deployment statuses: [ModelDeploymentDescription('warning','test-summation','1.0','localhost:31111/legion_model/test-summation:1.0-180830135752.2.8f237a9',5,2,'company-a',True,{'result': {'endpoints': {'default': {'input_params': False, 'name': 'default', 'use_df': False}, 'sum_and_pow': {'input_params': {'a': {'numpy_type': 'int32', 'type': 'Integer'}, 'b': {'numpy_type': 'int32', 'type': 'Integer'}}, 'name': 'sum_and_pow', 'use_df': False}}, 'model_id': 'test-summation', 'model_version': '1.0'}})]
2018-08-30 20:35:35,462 - INFO - Callback have not confirmed completion of the operation
2018-08-30 20:35:35,462 - DEBUG - Sleep before next request
2018-08-30 20:35:36,464 - INFO - Requesting actual status of affected deployments
2018-08-30 20:35:36,469 - DEBUG - Starting new HTTPS connection (1): edi-company-a.legion-dev.epm.kharlamov.biz
2018-08-30 20:35:37,810 - DEBUG - https://edi-company-a.legion-dev.epm.kharlamov.biz:443 "GET /api/1.0/inspect HTTP/1.1" 200 None
2018-08-30 20:35:37,817 - DEBUG - Got answer: [{'image': 'localhost:31111/legion_model/recognize-digits:1.0-180830135358.1.8f237a9', 'model': 'recognize-digits', 'model_api_info': {'result': {'endpoints': {'default': {'input_params': {'image': {'numpy_type': 'object', 'type': 'Image'}}, 'name': 'default', 'use_df': False}}, 'model_id': 'recognize-digits', 'model_version': '1.0'}}, 'model_api_ok': True, 'namespace': 'company-a', 'ready_replicas': 1, 'scale': 1, 'status': 'ok', 'version': '1.0'}, {'image': 'localhost:31111/legion_model/test-summation:1.0-180830135752.2.8f237a9', 'model': 'test-summation', 'model_api_info': {'result': {'endpoints': {'default': {'input_params': False, 'name': 'default', 'use_df': False}, 'sum_and_pow': {'input_params': {'a': {'numpy_type': 'int32', 'type': 'Integer'}, 'b': {'numpy_type': 'int32', 'type': 'Integer'}}, 'name': 'sum_and_pow', 'use_df': False}}, 'model_id': 'test-summation', 'model_version': '1.0'}}, 'model_api_ok': True, 'namespace': 'company-a', 'ready_replicas': 4, 'scale': 5, 'status': 'warning', 'version': '1.0'}] with code 200 for URL 'https://edi-company-a.legion-dev.epm.kharlamov.biz/api/1.0/inspect'
2018-08-30 20:35:37,818 - DEBUG - Server returned list of actual affected deployment statuses: [ModelDeploymentDescription('warning','test-summation','1.0','localhost:31111/legion_model/test-summation:1.0-180830135752.2.8f237a9',5,4,'company-a',True,{'result': {'endpoints': {'default': {'input_params': False, 'name': 'default', 'use_df': False}, 'sum_and_pow': {'input_params': {'a': {'numpy_type': 'int32', 'type': 'Integer'}, 'b': {'numpy_type': 'int32', 'type': 'Integer'}}, 'name': 'sum_and_pow', 'use_df': False}}, 'model_id': 'test-summation', 'model_version': '1.0'}})]
2018-08-30 20:35:37,818 - INFO - Callback have not confirmed completion of the operation
2018-08-30 20:35:37,818 - DEBUG - Sleep before next request
2018-08-30 20:35:38,819 - INFO - Requesting actual status of affected deployments
2018-08-30 20:35:38,824 - DEBUG - Starting new HTTPS connection (1): edi-company-a.legion-dev.epm.kharlamov.biz
2018-08-30 20:35:40,426 - DEBUG - https://edi-company-a.legion-dev.epm.kharlamov.biz:443 "GET /api/1.0/inspect HTTP/1.1" 200 None
2018-08-30 20:35:40,432 - DEBUG - Got answer: [{'image': 'localhost:31111/legion_model/recognize-digits:1.0-180830135358.1.8f237a9', 'model': 'recognize-digits', 'model_api_info': {'result': {'endpoints': {'default': {'input_params': {'image': {'numpy_type': 'object', 'type': 'Image'}}, 'name': 'default', 'use_df': False}}, 'model_id': 'recognize-digits', 'model_version': '1.0'}}, 'model_api_ok': True, 'namespace': 'company-a', 'ready_replicas': 1, 'scale': 1, 'status': 'ok', 'version': '1.0'}, {'image': 'localhost:31111/legion_model/test-summation:1.0-180830135752.2.8f237a9', 'model': 'test-summation', 'model_api_info': {'result': {'endpoints': {'default': {'input_params': False, 'name': 'default', 'use_df': False}, 'sum_and_pow': {'input_params': {'a': {'numpy_type': 'int32', 'type': 'Integer'}, 'b': {'numpy_type': 'int32', 'type': 'Integer'}}, 'name': 'sum_and_pow', 'use_df': False}}, 'model_id': 'test-summation', 'model_version': '1.0'}}, 'model_api_ok': True, 'namespace': 'company-a', 'ready_replicas': 4, 'scale': 5, 'status': 'warning', 'version': '1.0'}] with code 200 for URL 'https://edi-company-a.legion-dev.epm.kharlamov.biz/api/1.0/inspect'
2018-08-30 20:35:40,433 - DEBUG - Server returned list of actual affected deployment statuses: [ModelDeploymentDescription('warning','test-summation','1.0','localhost:31111/legion_model/test-summation:1.0-180830135752.2.8f237a9',5,4,'company-a',True,{'result': {'endpoints': {'default': {'input_params': False, 'name': 'default', 'use_df': False}, 'sum_and_pow': {'input_params': {'a': {'numpy_type': 'int32', 'type': 'Integer'}, 'b': {'numpy_type': 'int32', 'type': 'Integer'}}, 'name': 'sum_and_pow', 'use_df': False}}, 'model_id': 'test-summation', 'model_version': '1.0'}})]
2018-08-30 20:35:40,433 - INFO - Callback have not confirmed completion of the operation
2018-08-30 20:35:40,433 - DEBUG - Sleep before next request
2018-08-30 20:35:41,435 - INFO - Requesting actual status of affected deployments
2018-08-30 20:35:41,440 - DEBUG - Starting new HTTPS connection (1): edi-company-a.legion-dev.epm.kharlamov.biz
2018-08-30 20:35:42,879 - DEBUG - https://edi-company-a.legion-dev.epm.kharlamov.biz:443 "GET /api/1.0/inspect HTTP/1.1" 200 None
2018-08-30 20:35:42,884 - DEBUG - Got answer: [{'image': 'localhost:31111/legion_model/recognize-digits:1.0-180830135358.1.8f237a9', 'model': 'recognize-digits', 'model_api_info': {'result': {'endpoints': {'default': {'input_params': {'image': {'numpy_type': 'object', 'type': 'Image'}}, 'name': 'default', 'use_df': False}}, 'model_id': 'recognize-digits', 'model_version': '1.0'}}, 'model_api_ok': True, 'namespace': 'company-a', 'ready_replicas': 1, 'scale': 1, 'status': 'ok', 'version': '1.0'}, {'image': 'localhost:31111/legion_model/test-summation:1.0-180830135752.2.8f237a9', 'model': 'test-summation', 'model_api_info': {'result': {'endpoints': {'default': {'input_params': False, 'name': 'default', 'use_df': False}, 'sum_and_pow': {'input_params': {'a': {'numpy_type': 'int32', 'type': 'Integer'}, 'b': {'numpy_type': 'int32', 'type': 'Integer'}}, 'name': 'sum_and_pow', 'use_df': False}}, 'model_id': 'test-summation', 'model_version': '1.0'}}, 'model_api_ok': True, 'namespace': 'company-a', 'ready_replicas': 5, 'scale': 5, 'status': 'ok', 'version': '1.0'}] with code 200 for URL 'https://edi-company-a.legion-dev.epm.kharlamov.biz/api/1.0/inspect'
2018-08-30 20:35:42,885 - DEBUG - Server returned list of actual affected deployment statuses: [ModelDeploymentDescription('ok','test-summation','1.0','localhost:31111/legion_model/test-summation:1.0-180830135752.2.8f237a9',5,5,'company-a',True,{'result': {'endpoints': {'default': {'input_params': False, 'name': 'default', 'use_df': False}, 'sum_and_pow': {'input_params': {'a': {'numpy_type': 'int32', 'type': 'Integer'}, 'b': {'numpy_type': 'int32', 'type': 'Integer'}}, 'name': 'sum_and_pow', 'use_df': False}}, 'model_id': 'test-summation', 'model_version': '1.0'}})]
2018-08-30 20:35:42,885 - INFO - Callback have confirmed completion of the operation
```