### PR TITLE
[#412] Fixes Jenkins Robot tests for the Sklearn-income model

### DIFF
--- a/examples/Sklearn-Income/Jenkinsfile
+++ b/examples/Sklearn-Income/Jenkinsfile
@@ -17,5 +17,9 @@ node {
         stage('deploy'){
             legion.deploy()
         }
+
+        stage('run tests') {
+            legion.runTests()
+        }
     }
 }

--- a/examples/Sklearn-Income/tests/test_basic.py
+++ b/examples/Sklearn-Income/tests/test_basic.py
@@ -1,5 +1,5 @@
 #
-#    Copyright 2017 EPAM Systems
+#    Copyright 2018 EPAM Systems
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/examples/Sklearn-Income/tests/test_basic.py
+++ b/examples/Sklearn-Income/tests/test_basic.py
@@ -26,24 +26,23 @@ class BasicTest(unittest2.TestCase):
         self._client = ModelClient(os.environ.get(*legion.config.MODEL_ID), '1.1')
 
     def test_model(self):
-        example_data = {'age': 31,
-                        'capital-gain': 14084,
-                        'capital-loss': 0,
-                        'education': 'Bachelors',
-                        'education-num': 13,
-                        'fnlwgt': 77516,
-                        'hours-per-week': 40,
-                        'marital-status': 'Married-civ-spouse',
-                        'native-country': 'United-States',
-                        'occupation': 'Exec-managerial',
-                        'race': 'White',
-                        'relationship': 'Husband',
-                        'sex': 'Male',
-                        'workclass': 'Private'}
+        response = self._client.invoke(**{"age": "31",
+                                          "capital-gain": "14084",
+                                          "capital-loss": 0,
+                                          "education": "Bachelors",
+                                          "education-num": "13",
+                                          "fnlwgt": "77516",
+                                          "hours-per-week": "40",
+                                          "marital-status": "Married-civ-spouse",
+                                          "native-country": "United-States",
+                                          "occupation": "Exec-managerial",
+                                          "race": "White",
+                                          "relationship": "Husband",
+                                          "sex": "Male",
+                                          "workclass": "Private"
+                                          })
 
-        response = self._client.invoke(data=example_data)
-
-        self.assertEqual(response['result'], '1')
+        self.assertEqual(response['result'], 1)
 
 
 if __name__ == '__main__':

--- a/examples/Sklearn-Income/tests/test_basic.py
+++ b/examples/Sklearn-Income/tests/test_basic.py
@@ -23,7 +23,7 @@ import unittest2
 
 class BasicTest(unittest2.TestCase):
     def setUp(self):
-        self._client = ModelClient(os.environ.get(*legion.config.MODEL_ID), '1.0')
+        self._client = ModelClient(os.environ.get(*legion.config.MODEL_ID), '1.1')
 
     def test_model(self):
         example_data = {'age': 31,

--- a/examples/Sklearn-Income/tests/test_basic.py
+++ b/examples/Sklearn-Income/tests/test_basic.py
@@ -1,0 +1,50 @@
+#
+#    Copyright 2017 EPAM Systems
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+import os
+
+from legion.model import ModelClient
+import legion.config
+
+import unittest2
+
+
+class BasicTest(unittest2.TestCase):
+    def setUp(self):
+        self._client = ModelClient(os.environ.get(*legion.config.MODEL_ID), '1.0')
+
+    def test_model(self):
+        example_data = {'age': 31,
+                        'capital-gain': 14084,
+                        'capital-loss': 0,
+                        'education': 'Bachelors',
+                        'education-num': 13,
+                        'fnlwgt': 77516,
+                        'hours-per-week': 40,
+                        'marital-status': 'Married-civ-spouse',
+                        'native-country': 'United-States',
+                        'occupation': 'Exec-managerial',
+                        'race': 'White',
+                        'relationship': 'Husband',
+                        'sex': 'Male',
+                        'workclass': 'Private'}
+
+        response = self._client.invoke(data=example_data)
+
+        self.assertEqual(response['result'], '1')
+
+
+if __name__ == '__main__':
+    unittest2.main()

--- a/tests/robot/2_check_models.robot
+++ b/tests/robot/2_check_models.robot
@@ -9,7 +9,6 @@ Library             legion_test.robot.Jenkins
 Running, waiting and checks jobs in Jenkins
     [Documentation]  Build and check every example in Jenkins
     [Tags]  jenkins  models  enclave
-    Sleep    120s
     Connect to Jenkins endpoint
     Run, wait and check jenkins jobs for enclave     ${MODEL_TEST_ENCLAVE}
 

--- a/tests/robot/2_check_models.robot
+++ b/tests/robot/2_check_models.robot
@@ -15,7 +15,6 @@ Running, waiting and checks jobs in Jenkins
 Check Vertical Scailing
     [Documentation]  Runs "PERF TEST Vertical-Scaling" jenkins job to test vertical scailing
     [Tags]  jenkins model
-    
     :FOR  ${enclave}    IN    @{ENCLAVES}
     \  Connect to Jenkins endpoint
         Run Jenkins job                                         PERF TEST Vertical-Scaling   Enclave=${enclave}


### PR DESCRIPTION
This fixes Jenkins Robot tests because without tests for the Sklearn-income we did not have any metrics in the grafana and test failed.