### PR TITLE
[#420] Model test expected result fixed

### DIFF
--- a/tests/robot/5_check_edi_multi_versioned_models.robot
+++ b/tests/robot/5_check_edi_multi_versioned_models.robot
@@ -63,8 +63,8 @@ Check EDI undeploy all model instances by version
                     Should Be Equal As Integers     ${resp.rc}         0
     ${resp}=        Run EDI inspect by model id     ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}
                     Should Be Equal As Integers     ${resp.rc}              0
-                    Should not contain              ${resp.stdout}          ${TEST_MODEL_1_VERSION}
-                    Should contain                  ${resp.stdout}          ${TEST_MODEL_2_VERSION}
+                    Should not contain              ${resp.stdout}          |${TEST_MODEL_1_VERSION}
+                    Should contain                  ${resp.stdout}          |${TEST_MODEL_2_VERSION}
 
 Check EDI undeploy 1 of 2 models without version
     [Tags]  edi  cli  enclave   multi_versions


### PR DESCRIPTION
The case was 
'demo-abc-model |nexus-local.cc.epm.kharlamov.biz:443/legion/test-bare-model-api-model-2:0.8.0-20180903130526.23**1.0**29cab7 |1.1     |1     |1     |' 
contains '1.0'

Now we will check with the '|' symbol to be sure.