### PR TITLE
[#425] Edi test timeouts increased for the debugging in error cases

### DIFF
--- a/tests/robot/4_check_edi.robot
+++ b/tests/robot/4_check_edi.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation       Legion's EDI operational check
-Test Timeout        5 minutes
+Test Timeout        10 minutes
 Resource            resources/keywords.robot
 Resource            resources/variables.robot
 Variables           load_variables_from_profiles.py    ${PATH_TO_PROFILES_DIR}

--- a/tests/robot/4_check_edi.robot
+++ b/tests/robot/4_check_edi.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation       Legion's EDI operational check
-Test Timeout        10 minutes
+Test Timeout        6 minutes
 Resource            resources/keywords.robot
 Resource            resources/variables.robot
 Variables           load_variables_from_profiles.py    ${PATH_TO_PROFILES_DIR}

--- a/tests/robot/5_check_edi_multi_versioned_models.robot
+++ b/tests/robot/5_check_edi_multi_versioned_models.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation       Legion's EDI operational check
-Test Timeout        5 minutes
+Test Timeout        10 minutes
 Resource            resources/keywords.robot
 Resource            resources/variables.robot
 Variables           load_variables_from_profiles.py    ${PATH_TO_PROFILES_DIR}

--- a/tests/robot/5_check_edi_multi_versioned_models.robot
+++ b/tests/robot/5_check_edi_multi_versioned_models.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation       Legion's EDI operational check
-Test Timeout        10 minutes
+Test Timeout        6 minutes
 Resource            resources/keywords.robot
 Resource            resources/variables.robot
 Variables           load_variables_from_profiles.py    ${PATH_TO_PROFILES_DIR}


### PR DESCRIPTION
Increase tests timeout up to 10 minutes in order to get all stderr from legionctl commands.