### PR TITLE
[#441] Added cffi apk package for Edge docker image

### DIFF
--- a/k8s/edge/Dockerfile
+++ b/k8s/edge/Dockerfile
@@ -19,7 +19,7 @@ ENV DUMB_INIT_VERSION 1.2.0
 
 # Dumb-init, python3, lua
 RUN set -ex \
-  && apk add --no-cache --virtual .install-deps openssl \
+  && apk add --no-cache --virtual .install-deps openssl libffi-dev openssl-dev \
        python3 python3-dev bash g++ zlib zlib-dev jpeg jpeg-dev \
        ca-certificates gnupg openssl git curl luarocks5.3 \
   && luarocks-5.3 install lua-resty-statsd 3.0.3-1 \


### PR DESCRIPTION
Build of Edge docker image failed when we started it without cache, but compelted successfully on current jenkins due to cache. Adding of cffi package fixed the issue.
It's impossible for now to understand what is the reason of this issue, and what package changed.
This PR closes #442 