### PR TITLE
[#443] Modified Airflow worker permissions to enable ConfigMap creation

### DIFF
--- a/deploy/helms/airflow/templates/worker-rbac.yaml
+++ b/deploy/helms/airflow/templates/worker-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
 rules:
 - apiGroups: [""] # core API group
   resources: ["configmaps"]
-  verbs: ["watch", "get"]
+  verbs: ["list", "create", "get", "patch", "update"]
 - apiGroups: [""] # core API group
   resources: ["secrets"]
   verbs: ["watch", "get"]


### PR DESCRIPTION
Added appropriate permissions to Airflow worker so it will be able to create and save ConfigMaps.
This PR closes #443 