### PR TITLE
[#455] Locked Jenkins version to 2.121.3

### DIFF
--- a/k8s/jenkins/Dockerfile
+++ b/k8s/jenkins/Dockerfile
@@ -13,7 +13,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-FROM jenkins/jenkins:lts
+FROM jenkins/jenkins:2.121.3
 
 USER root
 RUN apt-get update && apt-get install --yes \


### PR DESCRIPTION
This PR closes #455 .
Jenkins has been recently updated (2018-09-12):
https://jenkins.io/changelog-stable/#v2.138.1
And API Token logic has been changed, same as UI:
_Replace single per-user API token with new system of multiple, revocable, unrecoverable API tokens with usage tracking._
Robot tests are not able to get Jenkins API Token due to changed UI.