### PR TITLE
[#334][#345] Legionctl tests with '*' param added to check multiple models actions

### DIFF
--- a/legion/legion/k8s/enclave.py
+++ b/legion/legion/k8s/enclave.py
@@ -211,8 +211,13 @@ class Enclave:
         """
         model_services = self.get_models(model_id, model_version)
 
-        if len(model_services) > 1 and not model_version:
-            raise Exception('Please specify version of model')
+        ignore_strictness = model_id == '*' or model_version == '*'
+
+        if len(model_services) > 1:
+            LOGGER.info('More than one model was found for filter: id={!r} version={!r}'
+                        .format(model_id, model_version))
+            if not ignore_strictness and not model_version:
+                raise Exception('Please specify version of model')
 
         if not model_services:
             if not ignore_not_found:

--- a/tests/robot/tests/4_edi_multi_versioned_models/4.0_check_edi_multi_versioned_models.robot
+++ b/tests/robot/tests/4_edi_multi_versioned_models/4.0_check_edi_multi_versioned_models.robot
@@ -18,7 +18,7 @@ Test Teardown       Run Keywords
 Check EDI availability in all enclaves
     [Setup]         NONE
     [Documentation]  Try to connect to EDI in each enclave
-    [Tags]  edi  cli  enclave   multi_versions
+    [Tags]  edi  cli  enclave  multi_versions
     :FOR    ${enclave}    IN    @{ENCLAVES}
     \  ${edi_state} =           Run EDI inspect  ${enclave}
     \  Log                      ${edi_state}
@@ -71,6 +71,24 @@ Check EDI undeploy 1 of 2 models without version
                     Should Be Equal As Integers     ${resp.rc}         2
                     Should contain                  ${resp.stderr}     Please specify version of model
 
+Check EDI undeploy all versioned model instances by id=*
+    [Documentation]  Try to undeploy all models by id=* through EDI console
+    [Tags]  edi  cli  enclave  multi_versions
+    ${resp}=        Run EDI undeploy without version    ${MODEL_TEST_ENCLAVE}    '*'
+                    Should Be Equal As Integers     ${resp.rc}         0
+    ${resp}=        Run EDI inspect by model id     ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}
+                    Should Be Equal As Integers     ${resp.rc}              0
+                    Should be empty                 ${resp.stdout}
+
+Check EDI undeploy all versioned model instances by versions=*
+    [Documentation]  Try to undeploy all models by versions=* through EDI console
+    [Tags]  edi  cli  enclave  multi_versions
+   ${resp}=         Run EDI undeploy with version   ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    '*'
+                    Should Be Equal As Integers     ${resp.rc}         0
+    ${resp}=        Run EDI inspect by model id     ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}
+                    Should Be Equal As Integers     ${resp.rc}              0
+                    Should be empty                 ${resp.stdout}
+
 Check EDI scale up 1 of 2 models with different versions but the same id
     [Tags]  edi  cli  enclave  multi_versions
     ${resp}=        Run EDI scale with version      ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    2   ${TEST_MODEL_1_VERSION}
@@ -116,6 +134,32 @@ Check EDI scale up 1 of 2 models without version
     ${resp}=        Run EDI scale                   ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    2
                     Should Be Equal As Integers     ${resp.rc}              2
                     Should contain                  ${resp.stderr}          Please specify version of model
+
+Check EDI scale up all instances for 2 models(diff versions) by versions=*
+    [Documentation]  Try to scale up 2 models with different versions but the same id by all versions through EDI console
+    [Tags]  edi  cli  enclave  multi_versions
+    ${resp}=        Run EDI scale with version      ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    2   '*'
+                    Should Be Equal As Integers     ${resp.rc}              0
+    ${resp}=        Run EDI inspect with parse by model id       ${MODEL_TEST_ENCLAVE}      ${TEST_MODEL_ID}
+    ${model_1}=     Find model information in edi   ${resp}      ${TEST_MODEL_ID}   ${TEST_MODEL_1_VERSION}
+                    Log                             ${model_1}
+    ${model_2}=     Find model information in edi   ${resp}      ${TEST_MODEL_ID}   ${TEST_MODEL_2_VERSION}
+                    Log                             ${model_2}
+                    Verify model info from edi      ${model_1}   ${TEST_MODEL_ID}   ${TEST_MODEL_IMAGE_1}   ${TEST_MODEL_1_VERSION}  2
+                    Verify model info from edi      ${model_2}   ${TEST_MODEL_ID}   ${TEST_MODEL_IMAGE_2}   ${TEST_MODEL_2_VERSION}  2
+
+Check EDI scale up all instances for 2 models(diff versions) by id=*
+    [Documentation]  Try to scale up 2 models with different versions but the same id by all ids through EDI console
+    [Tags]  edi  cli  enclave  multi_versions
+    ${resp}=        Run EDI scale                   ${MODEL_TEST_ENCLAVE}   '*'    2
+                    Should Be Equal As Integers     ${resp.rc}              0
+    ${resp}=        Run EDI inspect with parse by model id       ${MODEL_TEST_ENCLAVE}      ${TEST_MODEL_ID}
+    ${model_1}=     Find model information in edi   ${resp}      ${TEST_MODEL_ID}   ${TEST_MODEL_1_VERSION}
+                    Log                             ${model_1}
+    ${model_2}=     Find model information in edi   ${resp}      ${TEST_MODEL_ID}   ${TEST_MODEL_2_VERSION}
+                    Log                             ${model_2}
+                    Verify model info from edi      ${model_1}   ${TEST_MODEL_ID}   ${TEST_MODEL_IMAGE_1}   ${TEST_MODEL_1_VERSION}  2
+                    Verify model info from edi      ${model_2}   ${TEST_MODEL_ID}   ${TEST_MODEL_IMAGE_2}   ${TEST_MODEL_2_VERSION}  2
 
 Check EDI model inspect by model id return 2 models
     [Tags]  edi  cli  enclave  multi_versions
@@ -167,3 +211,19 @@ Check EDI model inspect by valid model id and invalid version
     ${resp}=   Run EDI inspect by model id and model version    ${MODEL_TEST_ENCLAVE}    ${TEST_MODEL_ID}   ${TEST_MODEL_1_VERSION}test
                     Should Be Equal As Integers                 ${resp.rc}          0
                     Should be empty                             ${resp.stdout}
+
+Check EDI model inspect by model id=* return all models
+    [Documentation]  Try to inspect 2 models by all ids through EDI console
+    [Tags]  edi  cli  enclave  multi_versions
+    ${resp}=        Run EDI inspect by model id    ${MODEL_TEST_ENCLAVE}   '*'
+                    Should Be Equal As Integers    ${resp.rc}         0
+                    Should contain                 ${resp.stdout}     ${TEST_MODEL_IMAGE_1}
+                    Should contain                 ${resp.stdout}     ${TEST_MODEL_IMAGE_2}
+
+Check EDI model inspect by model version=* return all models
+    [Documentation]  Try to inspect 2 models by all versions through EDI console
+    [Tags]  edi  cli  enclave  multi_versions
+    ${resp}=        Run EDI inspect by model id and model version    ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    '*'
+                    Should Be Equal As Integers    ${resp.rc}        0
+                    Should contain                 ${resp.stdout}    ${TEST_MODEL_IMAGE_1}
+                    Should contain                 ${resp.stdout}    ${TEST_MODEL_IMAGE_2}

--- a/tests/robot/tests/4_edi_multi_versioned_models/4.0_check_edi_multi_versioned_models.robot
+++ b/tests/robot/tests/4_edi_multi_versioned_models/4.0_check_edi_multi_versioned_models.robot
@@ -71,24 +71,6 @@ Check EDI undeploy 1 of 2 models without version
                     Should Be Equal As Integers     ${resp.rc}         2
                     Should contain                  ${resp.stderr}     Please specify version of model
 
-Check EDI undeploy all versioned model instances by id=*
-    [Documentation]  Try to undeploy all models by id=* through EDI console
-    [Tags]  edi  cli  enclave  multi_versions
-    ${resp}=        Run EDI undeploy without version    ${MODEL_TEST_ENCLAVE}    '*'
-                    Should Be Equal As Integers     ${resp.rc}         0
-    ${resp}=        Run EDI inspect by model id     ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}
-                    Should Be Equal As Integers     ${resp.rc}              0
-                    Should be empty                 ${resp.stdout}
-
-Check EDI undeploy all versioned model instances by versions=*
-    [Documentation]  Try to undeploy all models by versions=* through EDI console
-    [Tags]  edi  cli  enclave  multi_versions
-   ${resp}=         Run EDI undeploy with version   ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    '*'
-                    Should Be Equal As Integers     ${resp.rc}         0
-    ${resp}=        Run EDI inspect by model id     ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}
-                    Should Be Equal As Integers     ${resp.rc}              0
-                    Should be empty                 ${resp.stdout}
-
 Check EDI scale up 1 of 2 models with different versions but the same id
     [Tags]  edi  cli  enclave  multi_versions
     ${resp}=        Run EDI scale with version      ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    2   ${TEST_MODEL_1_VERSION}
@@ -134,32 +116,6 @@ Check EDI scale up 1 of 2 models without version
     ${resp}=        Run EDI scale                   ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    2
                     Should Be Equal As Integers     ${resp.rc}              2
                     Should contain                  ${resp.stderr}          Please specify version of model
-
-Check EDI scale up all instances for 2 models(diff versions) by versions=*
-    [Documentation]  Try to scale up 2 models with different versions but the same id by all versions through EDI console
-    [Tags]  edi  cli  enclave  multi_versions
-    ${resp}=        Run EDI scale with version      ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    2   '*'
-                    Should Be Equal As Integers     ${resp.rc}              0
-    ${resp}=        Run EDI inspect with parse by model id       ${MODEL_TEST_ENCLAVE}      ${TEST_MODEL_ID}
-    ${model_1}=     Find model information in edi   ${resp}      ${TEST_MODEL_ID}   ${TEST_MODEL_1_VERSION}
-                    Log                             ${model_1}
-    ${model_2}=     Find model information in edi   ${resp}      ${TEST_MODEL_ID}   ${TEST_MODEL_2_VERSION}
-                    Log                             ${model_2}
-                    Verify model info from edi      ${model_1}   ${TEST_MODEL_ID}   ${TEST_MODEL_IMAGE_1}   ${TEST_MODEL_1_VERSION}  2
-                    Verify model info from edi      ${model_2}   ${TEST_MODEL_ID}   ${TEST_MODEL_IMAGE_2}   ${TEST_MODEL_2_VERSION}  2
-
-Check EDI scale up all instances for 2 models(diff versions) by id=*
-    [Documentation]  Try to scale up 2 models with different versions but the same id by all ids through EDI console
-    [Tags]  edi  cli  enclave  multi_versions
-    ${resp}=        Run EDI scale                   ${MODEL_TEST_ENCLAVE}   '*'    2
-                    Should Be Equal As Integers     ${resp.rc}              0
-    ${resp}=        Run EDI inspect with parse by model id       ${MODEL_TEST_ENCLAVE}      ${TEST_MODEL_ID}
-    ${model_1}=     Find model information in edi   ${resp}      ${TEST_MODEL_ID}   ${TEST_MODEL_1_VERSION}
-                    Log                             ${model_1}
-    ${model_2}=     Find model information in edi   ${resp}      ${TEST_MODEL_ID}   ${TEST_MODEL_2_VERSION}
-                    Log                             ${model_2}
-                    Verify model info from edi      ${model_1}   ${TEST_MODEL_ID}   ${TEST_MODEL_IMAGE_1}   ${TEST_MODEL_1_VERSION}  2
-                    Verify model info from edi      ${model_2}   ${TEST_MODEL_ID}   ${TEST_MODEL_IMAGE_2}   ${TEST_MODEL_2_VERSION}  2
 
 Check EDI model inspect by model id return 2 models
     [Tags]  edi  cli  enclave  multi_versions
@@ -211,19 +167,3 @@ Check EDI model inspect by valid model id and invalid version
     ${resp}=   Run EDI inspect by model id and model version    ${MODEL_TEST_ENCLAVE}    ${TEST_MODEL_ID}   ${TEST_MODEL_1_VERSION}test
                     Should Be Equal As Integers                 ${resp.rc}          0
                     Should be empty                             ${resp.stdout}
-
-Check EDI model inspect by model id=* return all models
-    [Documentation]  Try to inspect 2 models by all ids through EDI console
-    [Tags]  edi  cli  enclave  multi_versions
-    ${resp}=        Run EDI inspect by model id    ${MODEL_TEST_ENCLAVE}   '*'
-                    Should Be Equal As Integers    ${resp.rc}         0
-                    Should contain                 ${resp.stdout}     ${TEST_MODEL_IMAGE_1}
-                    Should contain                 ${resp.stdout}     ${TEST_MODEL_IMAGE_2}
-
-Check EDI model inspect by model version=* return all models
-    [Documentation]  Try to inspect 2 models by all versions through EDI console
-    [Tags]  edi  cli  enclave  multi_versions
-    ${resp}=        Run EDI inspect by model id and model version    ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    '*'
-                    Should Be Equal As Integers    ${resp.rc}        0
-                    Should contain                 ${resp.stdout}    ${TEST_MODEL_IMAGE_1}
-                    Should contain                 ${resp.stdout}    ${TEST_MODEL_IMAGE_2}

--- a/tests/robot/tests/5_edi_all_models_affected/5.0_edi_all_models_affected.robot
+++ b/tests/robot/tests/5_edi_all_models_affected/5.0_edi_all_models_affected.robot
@@ -1,0 +1,76 @@
+*** Settings ***
+Documentation       Legion's EDI operational check
+Test Timeout        6 minutes
+Resource            ../../resources/keywords.robot
+Resource            ../../resources/variables.robot
+Variables           ../../load_variables_from_profiles.py    ${PATH_TO_PROFILES_DIR}
+Library             legion_test.robot.Utils
+Library             Collections
+Suite Setup         Choose cluster context    ${CLUSTER_NAME}
+Test Setup          Run Keywords
+...                 Run EDI deploy and check model started          ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_IMAGE_1}   ${TEST_MODEL_ID}    ${TEST_MODEL_1_VERSION}   AND
+...                 Run EDI deploy and check model started          ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_IMAGE_2}   ${TEST_MODEL_ID}    ${TEST_MODEL_2_VERSION}
+Test Teardown       Run Keywords
+...                 Run EDI undeploy by model version and check     ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}   ${TEST_MODEL_1_VERSION}   ${TEST_MODEL_IMAGE_1}    AND
+...                 Run EDI undeploy by model version and check     ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}   ${TEST_MODEL_2_VERSION}   ${TEST_MODEL_IMAGE_2}
+
+*** Test Cases ***
+Check EDI undeploy all versioned model instances by id=*
+    [Documentation]  Try to undeploy all models by id=* through EDI console
+    [Tags]  edi  cli  enclave  multi_versions
+    ${resp}=        Run EDI undeploy without version    ${MODEL_TEST_ENCLAVE}    '*'
+                    Should Be Equal As Integers     ${resp.rc}         0
+    ${resp}=        Run EDI inspect by model id     ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}
+                    Should Be Equal As Integers     ${resp.rc}              0
+                    Should be empty                 ${resp.stdout}
+
+Check EDI undeploy all versioned model instances by versions=*
+    [Documentation]  Try to undeploy all models by versions=* through EDI console
+    [Tags]  edi  cli  enclave  multi_versions
+   ${resp}=         Run EDI undeploy with version   ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    '*'
+                    Should Be Equal As Integers     ${resp.rc}         0
+    ${resp}=        Run EDI inspect by model id     ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}
+                    Should Be Equal As Integers     ${resp.rc}              0
+                    Should be empty                 ${resp.stdout}
+
+Check EDI scale up all instances for 2 models(diff versions) by versions=*
+    [Documentation]  Try to scale up 2 models with different versions but the same id by all versions through EDI console
+    [Tags]  edi  cli  enclave  multi_versions
+    ${resp}=        Run EDI scale with version      ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    2   '*'
+                    Should Be Equal As Integers     ${resp.rc}              0
+    ${resp}=        Run EDI inspect with parse by model id       ${MODEL_TEST_ENCLAVE}      ${TEST_MODEL_ID}
+    ${model_1}=     Find model information in edi   ${resp}      ${TEST_MODEL_ID}   ${TEST_MODEL_1_VERSION}
+                    Log                             ${model_1}
+    ${model_2}=     Find model information in edi   ${resp}      ${TEST_MODEL_ID}   ${TEST_MODEL_2_VERSION}
+                    Log                             ${model_2}
+                    Verify model info from edi      ${model_1}   ${TEST_MODEL_ID}   ${TEST_MODEL_IMAGE_1}   ${TEST_MODEL_1_VERSION}  2
+                    Verify model info from edi      ${model_2}   ${TEST_MODEL_ID}   ${TEST_MODEL_IMAGE_2}   ${TEST_MODEL_2_VERSION}  2
+
+Check EDI scale up all instances for 2 models(diff versions) by id=*
+    [Documentation]  Try to scale up 2 models with different versions but the same id by all ids through EDI console
+    [Tags]  edi  cli  enclave  multi_versions
+    ${resp}=        Run EDI scale                   ${MODEL_TEST_ENCLAVE}   '*'    2
+                    Should Be Equal As Integers     ${resp.rc}              0
+    ${resp}=        Run EDI inspect with parse by model id       ${MODEL_TEST_ENCLAVE}      ${TEST_MODEL_ID}
+    ${model_1}=     Find model information in edi   ${resp}      ${TEST_MODEL_ID}   ${TEST_MODEL_1_VERSION}
+                    Log                             ${model_1}
+    ${model_2}=     Find model information in edi   ${resp}      ${TEST_MODEL_ID}   ${TEST_MODEL_2_VERSION}
+                    Log                             ${model_2}
+                    Verify model info from edi      ${model_1}   ${TEST_MODEL_ID}   ${TEST_MODEL_IMAGE_1}   ${TEST_MODEL_1_VERSION}  2
+                    Verify model info from edi      ${model_2}   ${TEST_MODEL_ID}   ${TEST_MODEL_IMAGE_2}   ${TEST_MODEL_2_VERSION}  2
+
+Check EDI model inspect by model id=* return all models
+    [Documentation]  Try to inspect 2 models by all ids through EDI console
+    [Tags]  edi  cli  enclave  multi_versions
+    ${resp}=        Run EDI inspect by model id    ${MODEL_TEST_ENCLAVE}   '*'
+                    Should Be Equal As Integers    ${resp.rc}         0
+                    Should contain                 ${resp.stdout}     ${TEST_MODEL_IMAGE_1}
+                    Should contain                 ${resp.stdout}     ${TEST_MODEL_IMAGE_2}
+
+Check EDI model inspect by model version=* return all models
+    [Documentation]  Try to inspect 2 models by all versions through EDI console
+    [Tags]  edi  cli  enclave  multi_versions
+    ${resp}=        Run EDI inspect by model id and model version    ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    '*'
+                    Should Be Equal As Integers    ${resp.rc}        0
+                    Should contain                 ${resp.stdout}    ${TEST_MODEL_IMAGE_1}
+                    Should contain                 ${resp.stdout}    ${TEST_MODEL_IMAGE_2}


### PR DESCRIPTION
In this PR:
1. Tests added: 
- scale by id=* and by (id=id versions=*)
- undeploy by id=* and by (id=id + versions=*)
- inspect id=* and by (id=id versions=*)
2. Fixed legionctl behavior with such tests.