### PR TITLE
[#479] Remove redundadnt k8s properties changes

### DIFF
--- a/deploy/ansible/roles/legion_enclave/templates/legion-values.yaml.j2
+++ b/deploy/ansible/roles/legion_enclave/templates/legion-values.yaml.j2
@@ -2,6 +2,8 @@ rootDomain: {{ root_domain }}
 enclaveName: "{{ enclave }}"
 namespace: default
 
+log_level: {{ log_level }}
+
 package:
   version: "{{ legion_version }}"
   repository: "{{ pypi_repo }}"

--- a/deploy/helms/legion/templates/metrics/grafana.yaml
+++ b/deploy/helms/legion/templates/metrics/grafana.yaml
@@ -35,6 +35,8 @@ spec:
           value: "true"
         - name: GF_INSTALL_PLUGINS
           value: ""
+        - name: GF_LOG_LEVEL
+          value: "{{ .Values.log_level }}"
         - name: GF_GRAPHITE_DATASOURCE
         {{- if .Values.grafana.graphite }}
           value: "{{ .Values.grafana.graphite }}"

--- a/deploy/helms/legion/values.yaml
+++ b/deploy/helms/legion/values.yaml
@@ -5,6 +5,7 @@ enclaveName: unknown
 localDomain: "cluster.local"
 addLocalDomain: false
 
+log_level: info
 
 edi:
   enabled: true

--- a/deploy/profiles/legion-ci-app.epm.kharlamov.biz.yml
+++ b/deploy/profiles/legion-ci-app.epm.kharlamov.biz.yml
@@ -5,6 +5,9 @@ env_name: legion-ci-app
 base_domain: legion-ci-app.epm.kharlamov.biz
 route53_zone: epm.kharlamov.biz
 
+# Logging
+log_level: debug
+
 # System vars
 tmp_dir: /tmp/
 

--- a/deploy/profiles/legion-ci-infra.epm.kharlamov.biz.yml
+++ b/deploy/profiles/legion-ci-infra.epm.kharlamov.biz.yml
@@ -5,6 +5,9 @@ env_name: legion-ci-infra
 base_domain: legion-ci-infra.epm.kharlamov.biz
 route53_zone: epm.kharlamov.biz
 
+# Logging
+log_level: debug
+
 # System vars
 tmp_dir: /tmp/
 

--- a/deploy/profiles/legion-ci.epm.kharlamov.biz.yml
+++ b/deploy/profiles/legion-ci.epm.kharlamov.biz.yml
@@ -5,6 +5,9 @@ env_name: legion-ci
 base_domain: legion-ci.epm.kharlamov.biz
 route53_zone: epm.kharlamov.biz
 
+# Logging
+log_level: debug
+
 # System vars
 tmp_dir: /tmp/
 

--- a/deploy/profiles/legion-demo.epm.kharlamov.biz.yml
+++ b/deploy/profiles/legion-demo.epm.kharlamov.biz.yml
@@ -5,6 +5,9 @@ env_name: legion-demo
 base_domain: legion-demo.epm.kharlamov.biz
 route53_zone: epm.kharlamov.biz
 
+# Logging
+log_level: debug
+
 
 # System vars
 tmp_dir: /tmp/

--- a/deploy/profiles/legion-dev.epm.kharlamov.biz.yml
+++ b/deploy/profiles/legion-dev.epm.kharlamov.biz.yml
@@ -5,6 +5,9 @@ env_name: legion-dev
 base_domain: legion-dev.epm.kharlamov.biz
 route53_zone: epm.kharlamov.biz
 
+# Logging
+log_level: debug
+
 # System vars
 tmp_dir: /tmp/
 

--- a/deploy/profiles/legion-test.epm.kharlamov.biz.yml
+++ b/deploy/profiles/legion-test.epm.kharlamov.biz.yml
@@ -5,6 +5,9 @@ env_name: legion-test
 base_domain: legion-test.epm.kharlamov.biz
 route53_zone: epm.kharlamov.biz
 
+# Logging
+log_level: debug
+
 
 # System vars
 tmp_dir: /tmp/

--- a/deploy/profiles/profiles_template.yaml
+++ b/deploy/profiles/profiles_template.yaml
@@ -9,6 +9,10 @@ env_type: ~           # name of env. type, will be added in resource tags
 env_name: ~    # short name of env, will be added in resource tags
 
 
+# Logging
+log_level: ~  # log level: debug / info / warning / error
+
+
 # Ansible variables
 tmp_dir: ~                          # directory for storing temporary files (on host during deploy)
 git_key: ~    # SSH Git access key which will be copied to Jenkins in cluster

--- a/legion/.pylintrc
+++ b/legion/.pylintrc
@@ -3,3 +3,6 @@ max-line-length=120
 
 [BASIC]
 const-rgx=(([A-Z_][A-Za-z0-9_]*)|(__.*__))$
+
+[MESSAGES CONTROL]
+disable=W1202

--- a/legion/analyze_code.sh
+++ b/legion/analyze_code.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-pycodestyle --show-source --show-pep8 legion
-pycodestyle --show-source --show-pep8 tests --ignore E402,E126,W503,E731
+pycodestyle --show-source --show-pep8 legion --ignore W1202
+pycodestyle --show-source --show-pep8 tests --ignore E402,E126,W503,E731,W1202
 pydocstyle --source legion
 pylint legion

--- a/legion/legion/k8s/__init__.py
+++ b/legion/legion/k8s/__init__.py
@@ -22,7 +22,6 @@ from legion.k8s.definitions import ModelIdVersion, ModelDeploymentDescription
 from legion.k8s.definitions import STATUS_OK, STATUS_FAIL, STATUS_WARN
 from legion.k8s.definitions import EVENT_ADDED, EVENT_MODIFIED, EVENT_DELETED
 from legion.k8s.utils import build_client, get_current_namespace, load_config, load_secrets
-from legion.k8s.utils import CONNECTION_CONTEXT
 from legion.k8s.watch import ResourceWatch
 from legion.k8s.properties import K8SPropertyStorage, K8SConfigMapStorage, K8SSecretStorage
 from legion.k8s.exceptions import UnknownDeploymentForModelService

--- a/legion/legion/k8s/properties.py
+++ b/legion/legion/k8s/properties.py
@@ -34,9 +34,11 @@ import legion.containers.headers
 import legion.config
 import legion.model
 import legion.k8s.watch
+import legion.k8s.definitions
 import legion.k8s.utils
 import legion.k8s.services
 import legion.utils
+from pandas.tests.extension.conftest import data
 
 LOGGER = logging.getLogger(__name__)
 
@@ -290,9 +292,12 @@ class K8SPropertyStorage:
 
         :param source_dict: dict with readed values
         :type source_dict: dict[str, str]
-        :return: None
+        :return: bool -- is new data has been received
         """
-        self._state = source_dict
+        data_has_been_changed = self._state != source_dict
+        if data_has_been_changed:
+            self._state = source_dict
+        return data_has_been_changed
 
     def _write_data_to_dict(self):
         """
@@ -333,8 +338,9 @@ class K8SPropertyStorage:
         """
         Load data from K8S
 
-        :return: None
+        :return: bool -- is new data has been received
         """
+        data_has_been_changed = False
         try:
             LOGGER.debug('Reading {} {!r} in namespace {!r}'.format(self.__class__.__name__,
                                                                     self.k8s_name,
@@ -342,12 +348,13 @@ class K8SPropertyStorage:
 
             config_map_object = self._read_k8s_resource()
 
-            self._read_data_from_dict(config_map_object.data)
+            data_has_been_changed = self._read_data_from_dict(config_map_object.data)
         except Exception as load_exception:
             self._read_k8s_resource_exception_handler(load_exception)
 
         self._last_load_time = time.time()
         self._saved = True
+        return data_has_been_changed
 
     def _check_and_reload(self):
         """
@@ -446,9 +453,19 @@ class K8SPropertyStorage:
         LOGGER.info('Creating watch for object {!r}'.format(self))
         watch = self._build_k8s_resource_watch()
         for (event_type, event_object) in watch.stream:
-            LOGGER.info('Watch got new event. Type = {}'.format(event_type))
-            self.load()
-            yield (event_type, self.data)
+            LOGGER.info('Watch got new event. Type = {!r}'.format(event_type))
+            if event_type != legion.k8s.definitions.EVENT_DELETED:
+                data_has_been_changed = self._read_data_from_dict(event_object.data)
+                if data_has_been_changed:
+                    self._last_load_time = time.time()
+                    self._saved = True
+                    LOGGER.debug('Issuing properties change event {!r}'.format(event_type))
+                    yield (event_type, self.data)
+                else:
+                    LOGGER.warning('Ignoring new properties change event {!r} without real data update'
+                                   .format(event_type))
+            else:
+                LOGGER.error('Got DELETED event, ignoring...')
 
     def _call_callback(self):
         """
@@ -655,12 +672,16 @@ class K8SSecretStorage(K8SPropertyStorage):
 
         :param source_dict: dict with readed values
         :type source_dict: dict[str, str]
-        :return: None
+        :return: bool -- is new data has been received
         """
-        self._state = {
+        new_data = {
             k: base64.b64decode(v.encode('ascii')).decode('utf-8')
             for k, v in source_dict.items()
         }
+        data_has_been_changed = self._state != new_data
+        if data_has_been_changed:
+            self._state = new_data
+        return data_has_been_changed
 
     def _write_data_to_dict(self):
         """

--- a/legion/legion/k8s/properties.py
+++ b/legion/legion/k8s/properties.py
@@ -38,7 +38,6 @@ import legion.k8s.definitions
 import legion.k8s.utils
 import legion.k8s.services
 import legion.utils
-from pandas.tests.extension.conftest import data
 
 LOGGER = logging.getLogger(__name__)
 

--- a/legion/legion/k8s/utils.py
+++ b/legion/legion/k8s/utils.py
@@ -66,6 +66,7 @@ def build_client():
     try:
         kubernetes.config.load_incluster_config()
     except kubernetes.config.config_exception.ConfigException:
+        LOGGER.debug('Connecting to cluster using context {!r}'.format(CONNECTION_CONTEXT))
         kubernetes.config.load_kube_config(context=CONNECTION_CONTEXT)
 
     # Disable SSL warning for self-signed certificates

--- a/legion_test/legion_test/utils.py
+++ b/legion_test/legion_test/utils.py
@@ -34,7 +34,8 @@ def wait_until(condition, iteration_duration=5, iterations=10):
     :return: True or False -- is condition result has been changed to True
     """
     for _ in range(iterations):
-        if condition():
+        result = condition()
+        if result:
             return True
 
         time.sleep(iteration_duration)
@@ -68,6 +69,7 @@ class ContextThread(threading.Thread):
     """
     Context manager thread
     """
+
     def __init__(self, threaded_function, name='ContextThread'):
         """
         Construct context manager
@@ -80,6 +82,16 @@ class ContextThread(threading.Thread):
         threading.Thread.__init__(self, name=name)
         self.daemon = True
         self._function = threaded_function
+        self._ready = False
+
+    @property
+    def is_thread_ready(self):
+        """
+        Check is thread ready
+
+        :return: bool -- is thread ready or not
+        """
+        return self._ready
 
     def run(self):
         """
@@ -88,6 +100,7 @@ class ContextThread(threading.Thread):
         :return: None
         """
         try:
+            self._ready = True
             self._function()
         finally:
             LOGGER.debug('ContextThread finished his work')
@@ -121,4 +134,5 @@ class ContextThread(threading.Thread):
         :param exc_tb: exception traceback
         :return: None
         """
+        self._ready = False
         self.stop()

--- a/tests/python/test_k8s_introspection.py
+++ b/tests/python/test_k8s_introspection.py
@@ -21,6 +21,7 @@ import logging
 import unittest2
 
 import legion.k8s
+import legion.k8s.utils
 import legion.config
 import legion.external
 import legion_test.profiler_loader
@@ -42,8 +43,8 @@ class TestK8SIntrospection(unittest2.TestCase):
         """
         logging.basicConfig(level=logging.DEBUG)
 
-        legion.k8s.CONNECTION_CONTEXT = VARIABLES['CLUSTER_NAME']
-        LOGGER.info('K8S context has been set to {}'.format(legion.k8s.CONNECTION_CONTEXT))
+        legion.k8s.utils.CONNECTION_CONTEXT = VARIABLES['CLUSTER_NAME']
+        LOGGER.info('K8S context has been set to {}'.format(legion.k8s.utils.CONNECTION_CONTEXT))
 
     def _get_test_enclave(self):
         """

--- a/tests/python/test_k8s_model_operations.py
+++ b/tests/python/test_k8s_model_operations.py
@@ -25,6 +25,7 @@ import unittest.mock
 import unittest2
 
 import legion.k8s
+import legion.k8s.utils
 import legion.config
 import legion.containers.docker
 import legion.external
@@ -67,8 +68,8 @@ class TestK8SModelOperations(unittest2.TestCase):
         """
         logging.basicConfig(level=logging.DEBUG)
 
-        legion.k8s.CONNECTION_CONTEXT = VARIABLES['CLUSTER_NAME']
-        LOGGER.info('K8S context has been set to {}'.format(legion.k8s.CONNECTION_CONTEXT))
+        legion.k8s.utils.CONNECTION_CONTEXT = VARIABLES['CLUSTER_NAME']
+        LOGGER.info('K8S context has been set to {}'.format(legion.k8s.utils.CONNECTION_CONTEXT))
 
     def _remove_model_if_exists(self, model_id, model_version=None):
         """

--- a/tests/python/test_k8s_watching.py
+++ b/tests/python/test_k8s_watching.py
@@ -53,8 +53,8 @@ class TestK8SWatching(unittest2.TestCase):
         """
         logging.basicConfig(level=logging.DEBUG)
 
-        legion.k8s.CONNECTION_CONTEXT = VARIABLES['CLUSTER_NAME']
-        LOGGER.info('K8S context has been set to {}'.format(legion.k8s.CONNECTION_CONTEXT))
+        legion.k8s.utils.CONNECTION_CONTEXT = VARIABLES['CLUSTER_NAME']
+        LOGGER.info('K8S context has been set to {}'.format(legion.k8s.utils.CONNECTION_CONTEXT))
 
         try:
             legion.k8s.Enclave(TEST_ENCLAVE_NAME).delete()


### PR DESCRIPTION
This closes #479 
This filters k8s events that script gets on start and on watcher restarts