### PR TITLE
[#516] Split robot tests into 'apps' and 'infra'

### DIFF
--- a/tests/robot/0.1_check_components_auth.robot
+++ b/tests/robot/0.1_check_components_auth.robot
@@ -11,12 +11,12 @@ Test Setup          Choose cluster context            ${CLUSTER_NAME}
 
 *** Test Cases ***
 Check if K8S dashboard domain has been secured
-    [Tags]  core  security  auth
+    [Tags]  core  security  auth  infra
     [Template]    Check if component domain has been secured
     component=dashboard    enclave=${EMPTY}
 
 Check if Jenkins domain has been secured
-    [Tags]  core  security  auth
+    [Tags]  core  security  auth  infra
     [Template]    Check if component domain has been secured
     component=jenkins    enclave=${EMPTY}
 
@@ -32,94 +32,94 @@ Check if Jenkins domain has been secured
 #    component=grafana    enclave=${EMPTY}
 
 Check if Grafana enclave domain has been secured
-    [Tags]  core  security  auth
+    [Tags]  core  security  auth  infra
     [Template]    Check if component domain has been secured
     component=grafana    enclave=${MODEL_TEST_ENCLAVE}
 
 Check if Airflow enclave domain has been secured
-    [Tags]  core  security  auth
+    [Tags]  core  security  auth  infra
     [Template]    Check if component domain has been secured
     component=airflow    enclave=${MODEL_TEST_ENCLAVE}
 
 Check if Flower enclave domain has been secured
-    [Tags]  core  security  auth
+    [Tags]  core  security  auth  infra
     [Template]    Check if component domain has been secured
     component=flower    enclave=${MODEL_TEST_ENCLAVE}
 
 Check if K8S dashboard domain does not auth with invalid creds
-    [Tags]  core  security  auth
+    [Tags]  core  security  auth  infra
     [Template]    Secured component domain should not be accessible by invalid credentials
     component=dashboard    enclave=${EMPTY}
 
 Check if Jenkins domain does not auth with invalid creds
-    [Tags]  core  security  auth
+    [Tags]  core  security  auth  infra
     [Template]    Secured component domain should not be accessible by invalid credentials
     component=jenkins    enclave=${EMPTY}
 
 # TODO uncomment when would be secured
 #Check if Nexus domain does not auth with invalid creds
-#    [Tags]  core  security   auth
+#    [Tags]  core  security  auth  infra
 #    [Template]    Secured component domain should not be accessible by invalid credentials
 #    component=nexus    enclave=${EMPTY}
 #
 #Check if Grafana domain does not auth with invalid creds
-#    [Tags]  core  security   auth
+#    [Tags]  core  security  auth  infra
 #    [Template]    Secured component domain should not be accessible by invalid credentials
 #    component=grafana    enclave=${EMPTY}
 
 Check if Grafana enclave does not auth with invalid creds
-    [Tags]  core  security  auth
+    [Tags]  core  security  auth  infra
     [Template]    Secured component domain should not be accessible by invalid credentials
     component=grafana    enclave=${MODEL_TEST_ENCLAVE}
 
 Check if Airflow enclave does not auth with invalid creds
-    [Tags]  core  security  auth
+    [Tags]  core  security  auth  infra
     [Template]    Secured component domain should not be accessible by invalid credentials
     component=airflow    enclave=${MODEL_TEST_ENCLAVE}
 
 Check if Flower enclave domain does not auth with invalid creds
-    [Tags]  core  security  auth
+    [Tags]  core  security  auth  infra
     [Template]    Secured component domain should not be accessible by invalid credentials
     component=flower    enclave=${MODEL_TEST_ENCLAVE}
 
 Check if Jenkins domain can auth with valid creds
-    [Tags]  core  security  auth
+    [Tags]  core  security  auth  infra
     [Template]    Secured component domain should be accessible by valid credentials
     component=jenkins    enclave=${EMPTY}
 
 Check if Grafana enclave can auth with valid creds
-    [Tags]  core  security  auth
+    [Tags]  core  security  auth  infra
     [Template]    Secured component domain should be accessible by valid credentials
     component=grafana    enclave=${MODEL_TEST_ENCLAVE}
 
 Check if Airflow enclave can auth with valid creds
-    [Tags]  core  security  auth
+    [Tags]  core  security  auth  infra
     [Template]    Secured component domain should be accessible by valid credentials
     component=airflow    enclave=${MODEL_TEST_ENCLAVE}
 
 Check if Flower enclave can auth with valid creds
-    [Tags]  core  security  auth
+    [Tags]  core  security  auth  infra
     [Template]    Secured component domain should be accessible by valid credentials
     component=flower    enclave=${MODEL_TEST_ENCLAVE}
 
 Check if K8S dashboard domain can auth with valid creds
-    [Tags]  core  security  auth
+    [Tags]  core  security  auth  infra
     [Template]    Secured component domain should be accessible by valid credentials
     component=Dashboard    enclave=${EMPTY}
 
 # TODO uncomment when would be secured
 #Check if Nexus domain can auth with valid creds
-#    [Tags]  core  security  auth
+#    [Tags]  core  security  auth  infra
 #    [Template]    Secured component domain should be accessible by valid credentials
 #    component=nexus    enclave=${EMPTY}
 #
 #Check if Grafana domain can auth with valid creds
-#    [Tags]  core  security  auth
+#    [Tags]  core  security  auth  infra
 #    [Template]    Secured component domain should be accessible by valid credentials
 #    component=grafana    enclave=${EMPTY}
 
 Check if EDGE has been secured by token
-     [Tags]  core  security  auth
+     [Tags]  core  security  auth  infra
      [Documentation]  Deploy one model, and try to get model info without token
      ${resp}=        Run EDI deploy                      ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_IMAGE_1}
                      Should Be Equal As Integers         ${resp.rc}         0
@@ -132,7 +132,7 @@ Check if EDGE has been secured by token
      [Teardown]      Run EDI undeploy by model version and check     ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}   ${TEST_MODEL_1_VERSION}   ${TEST_MODEL_IMAGE_1}
 
 Check if EDGE does not authorize with invalid token
-     [Tags]  core  security  auth
+     [Tags]  core  security  auth  infra
      [Documentation]  Deploy one model, and try to get model info with invalid token
      ${invalid_token} =   Set Variable    eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1MzU2NDA5MDd9.-LIIJjF-Gf37eFbFl0Q_PpQyYWW_A-D9xNW7hsr4Efk
      ${resp}=        Run EDI deploy                      ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_IMAGE_1}
@@ -146,7 +146,7 @@ Check if EDGE does not authorize with invalid token
      [Teardown]      Run EDI undeploy by model version and check     ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}   ${TEST_MODEL_1_VERSION}   ${TEST_MODEL_IMAGE_1}
 
 Check if EDGE authorize with valid token
-     [Tags]  core  security  auth
+     [Tags]  core  security  auth  infra
      [Documentation]  Deploy one model, and try to get model info with valid token
      ${resp}=        Run EDI deploy                      ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_IMAGE_1}
                      Should Be Equal As Integers         ${resp.rc}         0

--- a/tests/robot/0.2_check_clusterwide.robot
+++ b/tests/robot/0.2_check_clusterwide.robot
@@ -13,19 +13,19 @@ Test Teardown       Close All Browsers
 *** Test Cases ***
 Checking if all core domains have been registered
     [Documentation]  Check that all required core DNS A records has been registered
-    [Tags]  core  dns
+    [Tags]  core  dns  infra
     :FOR    ${subdomain}    IN    @{SUBDOMAINS}
     \  Check domain exists  ${subdomain}.${HOST_BASE_DOMAIN}
 
 Checking if all enclave domains have been registered
     [Documentation]  Check that all required enclave DNS A records has been registered
-    [Tags]  core  dns
+    [Tags]  core  dns  infra
     :FOR    ${enclave}    IN    @{ENCLAVES}
     \   Check if all enclave domains are registered      ${enclave}
 
 Checking if all replica sets, stateful sets, replication controllers are up and running
     [Documentation]  Gather information from kubernetes through API and check state of all required componens
-    [Tags]  k8s
+    [Tags]  k8s  infra
     Replica set is running                   ${DEPLOYMENT}-core-nexus
     Replication controller is running        ${DEPLOYMENT}-core-jenkins
     Replication controller is running        ${DEPLOYMENT}-core-graphite
@@ -37,14 +37,14 @@ Checking if all replica sets, stateful sets, replication controllers are up and 
 
 Check Nexus availability
     [Documentation]  Check Nexus UI availability
-    [Tags]  nexus  ui
+    [Tags]  nexus  ui  infra
     Sleep  60
     Open Nexus                              /
     Wait Nexus componens in menu
 
 Check Nexus Components available
     [Documentation]  Check that Nexus storages (components) are ready
-    [Tags]  nexus  ui
+    [Tags]  nexus  ui  apps
     Open Nexus                              /#browse/browse/components
     ${componentNames}=                      Get Nexus components table
 #    List Should Contain Value               ${componentNames}           docker-hosted
@@ -53,7 +53,7 @@ Check Nexus Components available
 
 Check enclave Grafana availability
     [Documentation]  Try to connect to Grafana in each enclave
-    [Tags]  grafana  enclave
+    [Tags]  grafana  enclave  infra
     :FOR    ${enclave}    IN    @{ENCLAVES}
     \  Connect to enclave Grafana     ${enclave}
 

--- a/tests/robot/1_check_airflow.robot
+++ b/tests/robot/1_check_airflow.robot
@@ -6,6 +6,6 @@ Variables           load_variables_from_profiles.py   ${PATH_TO_PROFILES_DIR}
 *** Test Cases ***
 Check test dags should not fail
     [Documentation]  Connect to Airflow and check the status of test dags are not failed
-    [Tags]  airflow  airflow-api
+    [Tags]  airflow  airflow-api  apps
     :FOR    ${enclave}    IN    @{ENCLAVES}
     \  Invoke and check test dags for valid status code  ${enclave}

--- a/tests/robot/2_check_models.robot
+++ b/tests/robot/2_check_models.robot
@@ -15,14 +15,14 @@ Suite Setup         Run Keywords
 *** Test Cases ***
 Running, waiting and checks jobs in Jenkins
     [Documentation]  Build and check every example in Jenkins
-    [Tags]  jenkins  models  enclave
+    [Tags]  jenkins  models  enclave  apps
     Connect to Jenkins endpoint
     :FOR  ${model_name}  IN  @{JENKINS_JOBS}
     \    Test model pipeline result   ${model_name}   ${MODEL_TEST_ENCLAVE}
 
 Checking property update callback
     [Documentation]  Build and check model that uses property system
-    [Tags]  jenkins  models  enclave  props
+    [Tags]  jenkins  models  enclave  props  apps
     Connect to Jenkins endpoint
     ${model_id}    ${model_version} =   Test model pipeline result   ${MODEL_WITH_PROPS}   ${MODEL_TEST_ENCLAVE}
     Log                                 Model with id = ${model_id} and version = ${model_version} has been deployed
@@ -45,7 +45,7 @@ Checking property update callback
 
 Check Vertical Scailing
     [Documentation]  Runs "PERF TEST Vertical-Scaling" jenkins job to test vertical scailing
-    [Tags]  jenkins  model  scaling
+    [Tags]  k8s  scaling  infra
     :FOR  ${enclave}    IN    @{ENCLAVES}
     \  Connect to Jenkins endpoint
         Run Jenkins job                                         PERF TEST Vertical-Scaling   Enclave=${enclave}

--- a/tests/robot/3_check_flower.robot
+++ b/tests/robot/3_check_flower.robot
@@ -10,14 +10,14 @@ Test Setup          Choose cluster context            ${CLUSTER_NAME}
 *** Test Cases ***
 Check if flower available
     [Documentation]  Check if Flower UI is available
-    [Tags]  airflow  flower  scale
+    [Tags]  airflow  flower  scale  infra
     :FOR    ${enclave}    IN    @{ENCLAVES}
     \  Connect to enclave Flower     ${enclave}
         Check if flower online
 
 Check if flower scale up works properly
     [Documentation]  Scale up Flower deployment and check if number of celery workers increases
-    [Tags]  airflow  flower  scale
+    [Tags]  airflow  flower  scale  infra
     :FOR    ${enclave}    IN    @{ENCLAVES}
     \  Connect to enclave Flower     ${enclave}
        ${workers_number} =             Get number of workers from Flower
@@ -33,7 +33,7 @@ Check if flower scale up works properly
 
 Check if flower scale down works properly
     [Documentation]  Scale down Flower deployment and check if number of celery workers decreases
-    [Tags]  airflow  flower  scale
+    [Tags]  airflow  flower  scale  infra
     :FOR    ${enclave}    IN    @{ENCLAVES}
     \  Connect to enclave Flower     ${enclave}
        ${workers_number} =             Get number of workers from Flower

--- a/tests/robot/4_check_edi.robot
+++ b/tests/robot/4_check_edi.robot
@@ -14,7 +14,7 @@ Test Teardown       Run EDI undeploy model without version and check    ${MODEL_
 Check EDI availability in all enclaves
     [Setup]         NONE
     [Documentation]  Try to connect to EDI in each enclave
-    [Tags]  edi  cli  enclave   one_version
+    [Tags]  edi  cli  enclave  infra
     :FOR    ${enclave}      IN                            @{ENCLAVES}
     \       ${edi_state}=   Run EDI inspect               ${enclave}
     \                       Should Be Equal As Integers   ${edi_state.rc}     0
@@ -23,7 +23,7 @@ Check EDI availability in all enclaves
 Check EDI deploy procedure
     [Setup]         Run EDI undeploy model without version and check    ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}
     [Documentation]  Try to deploy dummy model through EDI console
-    [Tags]  edi  cli  enclave   one_version
+    [Tags]  edi  cli  enclave  one_version  apps
     ${resp}=        Run EDI deploy                      ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_IMAGE_1}
                     Should Be Equal As Integers         ${resp.rc}         0
     ${response}=    Check model started                 ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    ${TEST_MODEL_1_VERSION}
@@ -40,7 +40,7 @@ Check EDI deploy with scale to 0
 Check EDI deploy with scale to 1
     [Setup]         Run EDI undeploy model without version and check    ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}
     [Documentation]  Try to deploy dummy model through EDI console
-    [Tags]  edi  cli  enclave  one_version
+    [Tags]  edi  cli  enclave  one_version  apps
     ${resp}=        Run EDI deploy with scale      ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_IMAGE_1}   1
                     Should Be Equal As Integers    ${resp.rc}         0
     ${response}=    Check model started            ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    ${TEST_MODEL_1_VERSION}
@@ -54,7 +54,7 @@ Check EDI deploy with scale to 1
 Check EDI deploy with scale to 2
     [Setup]         Run EDI undeploy model without version and check    ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}
     [Documentation]  Try to deploy dummy model through EDI console
-    [Tags]  edi  cli  enclave  one_version
+    [Tags]  edi  cli  enclave  one_version  apps
     ${resp}=        Run EDI deploy with scale      ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_IMAGE_1}   2
                     Should Be Equal As Integers    ${resp.rc}         0
     ${response}=    Check model started            ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    ${TEST_MODEL_1_VERSION}
@@ -68,7 +68,7 @@ Check EDI deploy with scale to 2
 Check EDI invalid model name deploy procedure
     [Setup]         Run EDI undeploy model without version and check    ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}
     [Documentation]  Try to deploy dummy invalid model name through EDI console
-    [Tags]  edi  cli  enclave  one_version
+    [Tags]  edi  cli  enclave  one_version  apps
     ${resp}=        Run EDI deploy                ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_IMAGE_1}test
                     Should Be Equal As Integers   ${resp.rc}         2
                     Should Contain                ${resp.stderr}     Can't get image labels for  ${TEST_MODEL_IMAGE_1}test
@@ -76,7 +76,7 @@ Check EDI invalid model name deploy procedure
 Check EDI double deploy procedure for the same model
     [Setup]         Run EDI undeploy model without version and check    ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}
     [Documentation]  Try to deploy twice the same dummy model through EDI console
-    [Tags]  edi  cli  enclave  one_version
+    [Tags]  edi  cli  enclave  one_version  apps
     ${resp}=        Run EDI deploy                ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_IMAGE_1}
                     Should Be Equal As Integers   ${resp.rc}         0
     ${response}=    Check model started           ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    ${TEST_MODEL_1_VERSION}
@@ -88,7 +88,7 @@ Check EDI double deploy procedure for the same model
 
 Check EDI undeploy procedure
     [Documentation]  Try to undeploy dummy valid model through EDI console
-    [Tags]  edi  cli  enclave  one_version
+    [Tags]  edi  cli  enclave  one_version  apps
     ${resp}=        Run EDI undeploy without version    ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}
                     Should Be Equal As Integers         ${resp.rc}         0
     ${resp}=        Run EDI inspect                     ${MODEL_TEST_ENCLAVE}
@@ -97,7 +97,7 @@ Check EDI undeploy procedure
 
 Check EDI scale up procedure
     [Documentation]  Try to scale up model through EDI console
-    [Tags]  edi  cli  enclave  one_version
+    [Tags]  edi  cli  enclave  one_version  apps
     ${resp}=        Run EDI scale                  ${MODEL_TEST_ENCLAVE}    ${TEST_MODEL_ID}    2
                     Should Be Equal As Integers    ${resp.rc}           0
     ${resp}=        Run EDI inspect with parse     ${MODEL_TEST_ENCLAVE}
@@ -107,7 +107,7 @@ Check EDI scale up procedure
 
 Check EDI scale down procedure
     [Documentation]  Try to scale up model through EDI console
-    [Tags]  edi  cli  enclave  one_version
+    [Tags]  edi  cli  enclave  one_version  apps
     ${resp}=        Run EDI scale                  ${MODEL_TEST_ENCLAVE}    ${TEST_MODEL_ID}    2
                     Should Be Equal As Integers    ${resp.rc}          0
     ${resp}=        Run EDI inspect with parse     ${MODEL_TEST_ENCLAVE}
@@ -124,28 +124,28 @@ Check EDI scale down procedure
 
 Check EDI scale to 0 procedure
     [Documentation]  Try to scale to 0 model through EDI console
-    [Tags]  edi  cli  enclave  one_version
+    [Tags]  edi  cli  enclave  one_version  apps
     ${resp}=        Run EDI scale                  ${MODEL_TEST_ENCLAVE}    ${TEST_MODEL_ID}    0
                     Should Be Equal As Integers    ${resp.rc}          2
                     Should contain                 ${resp.stderr}      Invalid scale parameter: should be greater then 0
 
 Check EDI invalid model id scale up procedure
     [Documentation]  Try to scale up dummy model with invalid name through EDI console
-    [Tags]  edi  cli  enclave  one_version
+    [Tags]  edi  cli  enclave  one_version  apps
     ${resp}=        Run EDI scale                ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}test   2
                     Should Be Equal As Integers  ${resp.rc}         2
                     Should contain               ${resp.stderr}     No one model can be found
 
 Check EDI enclave inspect procedure
     [Documentation]  Try to inspect enclave through EDI console
-    [Tags]  edi  cli  enclave  one_version
+    [Tags]  edi  cli  enclave  one_version  apps
     ${resp}=        Run EDI inspect                ${MODEL_TEST_ENCLAVE}
                     Should Be Equal As Integers    ${resp.rc}          0
                     Should contain                 ${resp.stdout}      ${TEST_MODEL_ID}
 
 Check EDI invalid enclave name inspect procedure
     [Documentation]  Try to inspect enclave through EDI console
-    [Tags]  edi  cli  enclave  one_version
+    [Tags]  edi  cli  enclave  one_version  apps
     ${resp}=        Run EDI inspect                ${MODEL_TEST_ENCLAVE}test
                     Should Be Equal As Integers    ${resp.rc}          2
                     Should contain                 ${resp.stderr}      ERROR - Failed to connect
@@ -153,7 +153,7 @@ Check EDI invalid enclave name inspect procedure
 Check EDI enclave inspect procedure without deployed model
     [Setup]         NONE
     [Documentation]  Try inspect through EDI console on empty enclave
-    [Tags]  edi  cli  enclave  one_version
+    [Tags]  edi  cli  enclave  one_version  apps
     ${resp}=        Run EDI inspect                ${MODEL_TEST_ENCLAVE}
                     Should Be Equal As Integers    ${resp.rc}          0
                     Should Not Contain             ${resp.stdout}      ${TEST_MODEL_ID}

--- a/tests/robot/5_check_edi_multi_versioned_models.robot
+++ b/tests/robot/5_check_edi_multi_versioned_models.robot
@@ -18,7 +18,7 @@ Test Teardown       Run Keywords
 Check EDI availability in all enclaves
     [Setup]         NONE
     [Documentation]  Try to connect to EDI in each enclave
-    [Tags]  edi  cli  enclave   multi_versions
+    [Tags]  edi  cli  enclave  multi_versions
     :FOR    ${enclave}    IN    @{ENCLAVES}
     \  ${edi_state} =           Run EDI inspect  ${enclave}
     \  Log                      ${edi_state}
@@ -27,7 +27,7 @@ Check EDI availability in all enclaves
 
 Check EDI deploy 2 models with different versions but the same id
     [Setup]         NONE
-    [Tags]  edi  cli  enclave  multi_versions
+    [Tags]  edi  cli  enclave  multi_versions  apps
     ${resp}=        Run EDI deploy                      ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_IMAGE_1}
                     Should Be Equal As Integers         ${resp.rc}         0
     ${resp}=        Check model started                 ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    ${TEST_MODEL_1_VERSION}
@@ -38,7 +38,7 @@ Check EDI deploy 2 models with different versions but the same id
                     Should contain                      ${resp}                 "model_version": "${TEST_MODEL_2_VERSION}"
 
 Check EDI undeploy 1 of 2 models with different versions but the same id
-    [Tags]  edi  cli  enclave  multi_versions
+    [Tags]  edi  cli  enclave  multi_versions  apps
     ${resp}=        Run EDI undeploy with version   ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    ${TEST_MODEL_1_VERSION}
                     Should Be Equal As Integers     ${resp.rc}         0
     ${resp}=        Run EDI inspect by model id     ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}
@@ -47,7 +47,7 @@ Check EDI undeploy 1 of 2 models with different versions but the same id
                     Should contain                  ${resp.stdout}          ${TEST_MODEL_IMAGE_2}
 
 Check EDI undeploy all model instances by version
-    [Tags]  edi  cli  enclave  multi_versions
+    [Tags]  edi  cli  enclave  multi_versions  apps
     ${resp}=        Run EDI scale with version      ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    2   ${TEST_MODEL_1_VERSION}
                     Should Be Equal As Integers     ${resp.rc}              0
     ${resp}=        Run EDI inspect with parse by model id       ${MODEL_TEST_ENCLAVE}      ${TEST_MODEL_ID}
@@ -66,13 +66,13 @@ Check EDI undeploy all model instances by version
                     Should contain                  ${resp.stdout}          |${TEST_MODEL_2_VERSION}
 
 Check EDI undeploy 1 of 2 models without version
-    [Tags]  edi  cli  enclave  multi_versions
+    [Tags]  edi  cli  enclave  multi_versions  apps
     ${resp}=   Run EDI undeploy without version   ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}
                     Should Be Equal As Integers        ${resp.rc}         2
                     Should contain                     ${resp.stderr}     Please specify version of model
 
 Check EDI scale up 1 of 2 models with different versions but the same id
-    [Tags]  edi  cli  enclave  multi_versions
+    [Tags]  edi  cli  enclave  multi_versions  apps
     ${resp}=        Run EDI scale with version      ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    2   ${TEST_MODEL_1_VERSION}
                     Should Be Equal As Integers     ${resp.rc}              0
     ${resp}=        Run EDI inspect with parse by model id       ${MODEL_TEST_ENCLAVE}      ${TEST_MODEL_ID}
@@ -84,7 +84,7 @@ Check EDI scale up 1 of 2 models with different versions but the same id
                     Verify model info from edi      ${model_2}   ${TEST_MODEL_ID}   ${TEST_MODEL_IMAGE_2}   ${TEST_MODEL_2_VERSION}  1
 
 Check EDI scale down 1 of 2 models with different versions but the same id
-    [Tags]  edi  cli  enclave  multi_versions
+    [Tags]  edi  cli  enclave  multi_versions  apps
     ${resp}=        Run EDI scale with version      ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    2   ${TEST_MODEL_1_VERSION}
                     Should Be Equal As Integers     ${resp.rc}              0
     ${resp}=        Run EDI inspect with parse by model id       ${MODEL_TEST_ENCLAVE}      ${TEST_MODEL_ID}
@@ -106,64 +106,64 @@ Check EDI scale down 1 of 2 models with different versions but the same id
                     Verify model info from edi      ${model_2}   ${TEST_MODEL_ID}   ${TEST_MODEL_IMAGE_2}   ${TEST_MODEL_2_VERSION}  1
 
 Check EDI scale up 1 of 2 models by invalid version
-    [Tags]  edi  cli  enclave  multi_versions
+    [Tags]  edi  cli  enclave  multi_versions  apps
     ${resp}=        Run EDI scale with version      ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    2   ${TEST_MODEL_1_VERSION}121
                     Should Be Equal As Integers     ${resp.rc}              2
                     Should contain                  ${resp.stderr}          No one model can be found
 
 Check EDI scale up 1 of 2 models without version
-    [Tags]  edi  cli  enclave  multi_versions
+    [Tags]  edi  cli  enclave  multi_versions  apps
     ${resp}=        Run EDI scale                   ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}    2
                     Should Be Equal As Integers     ${resp.rc}              2
                     Should contain                  ${resp.stderr}          Please specify version of model
 
 Check EDI model inspect by model id return 2 models
-    [Tags]  edi  cli  enclave  multi_versions
+    [Tags]  edi  cli  enclave  multi_versions  apps
     ${resp}=   Run EDI inspect by model id     ${MODEL_TEST_ENCLAVE}    ${TEST_MODEL_ID}
                     Should Be Equal As Integers     ${resp.rc}          0
                     Should contain                  ${resp.stdout}      ${TEST_MODEL_IMAGE_1}
                     Should contain                  ${resp.stdout}      ${TEST_MODEL_IMAGE_2}
 
 Check EDI model inspect by model version return 1 model
-    [Tags]  edi  cli  enclave  multi_versions
+    [Tags]  edi  cli  enclave  multi_versions  apps
     ${resp}=   Run EDI inspect by model version    ${MODEL_TEST_ENCLAVE}    ${TEST_MODEL_1_VERSION}
                     Should Be Equal As Integers         ${resp.rc}          0
                     Should contain                      ${resp.stdout}      ${TEST_MODEL_IMAGE_1}
                     Should not contain                  ${resp.stdout}      ${TEST_MODEL_IMAGE_2}
 
 Check EDI model inspect by model id and version return 1 model
-    [Tags]  edi  cli  enclave  multi_versions
+    [Tags]  edi  cli  enclave  multi_versions  apps
     ${resp}=   Run EDI inspect by model id and model version    ${MODEL_TEST_ENCLAVE}   ${TEST_MODEL_ID}      ${TEST_MODEL_1_VERSION}
                     Should Be Equal As Integers                      ${resp.rc}         0
                     Should contain                                   ${resp.stdout}     ${TEST_MODEL_IMAGE_1}
                     Should not contain                               ${resp.stdout}     ${TEST_MODEL_IMAGE_2}
 
 Check EDI model inspect by invalid model id
-    [Tags]  edi  cli  enclave  multi_versions
+    [Tags]  edi  cli  enclave  multi_versions  apps
     ${resp}=   Run EDI inspect by model id     ${MODEL_TEST_ENCLAVE}    ${TEST_MODEL_ID}test
                     Should Be Equal As Integers     ${resp.rc}          0
                     Should be empty                 ${resp.stdout}
 
 Check EDI model inspect by invalid model version
-    [Tags]  edi  cli  enclave  multi_versions
+    [Tags]  edi  cli  enclave  multi_versions  apps
     ${resp}=   Run EDI inspect by model version    ${MODEL_TEST_ENCLAVE}  ${TEST_MODEL_1_VERSION}test
                     Should Be Equal As Integers         ${resp.rc}        0
                     Should be empty                     ${resp.stdout}
 
 Check EDI model inspect by invalid model id and invalid version
-    [Tags]  edi  cli  enclave  multi_versions
+    [Tags]  edi  cli  enclave  multi_versions  apps
     ${resp}=   Run EDI inspect by model id and model version    ${MODEL_TEST_ENCLAVE}    ${TEST_MODEL_ID}test   ${TEST_MODEL_1_VERSION}test
                     Should Be Equal As Integers                      ${resp.rc}          0
                     Should be empty                                  ${resp.stdout}
 
 Check EDI model inspect by invalid model id and valid version
-    [Tags]  edi  cli  enclave  multi_versions
+    [Tags]  edi  cli  enclave  multi_versions  apps
     ${resp}=   Run EDI inspect by model id and model version    ${MODEL_TEST_ENCLAVE}    ${TEST_MODEL_ID}test   ${TEST_MODEL_1_VERSION}
                     Should Be Equal As Integers                      ${resp.rc}          0
                     Should be empty                                  ${resp.stdout}
 
 Check EDI model inspect by valid model id and invalid version
-    [Tags]  edi  cli  enclave  multi_versions
+    [Tags]  edi  cli  enclave  multi_versions  apps
     ${resp}=   Run EDI inspect by model id and model version    ${MODEL_TEST_ENCLAVE}    ${TEST_MODEL_ID}   ${TEST_MODEL_1_VERSION}test
                     Should Be Equal As Integers                      ${resp.rc}          0
                     Should be empty                                  ${resp.stdout}

--- a/tests/robot/5_check_fluentd.robot
+++ b/tests/robot/5_check_fluentd.robot
@@ -11,12 +11,12 @@ Library             legion_test.robot.Utils
 *** Test Cases ***
 Check feedback gathering
     [Documentation]  Checking that feedback gathering works
-    [Tags]  feedback  fluentd
+    [Tags]  feedback  fluentd  infra
     Send feedback data      ${HOST_PROTOCOL}://feedback-${MODEL_TEST_ENCLAVE}.${HOST_BASE_DOMAIN}   ${FEEDBACK_TAG}  a=0
 
 Check feedback processing
     [Documentation]  Checking that feedback process works normally
-    [Tags]  feedback  fluentd  aws
+    [Tags]  feedback  fluentd  aws  apps
     Choose bucket           ${FEEDBACK__BUCKET}
 
     ${a_value} =            Generate Random String   4                  [NUMBERS]


### PR DESCRIPTION
All robot tests which are connected with k8s work and checking that all components of the legion deployed were marked by 'infra' tag. 
Other tests which check only any app functionality were marked by tag 'apps'.