### PR TITLE
[#518] [#511] Scale down node after vertical scaling test

### DIFF
--- a/deploy/ansible/roles/k8s_resources/templates/autoscaler.yaml.j2
+++ b/deploy/ansible/roles/k8s_resources/templates/autoscaler.yaml.j2
@@ -126,7 +126,7 @@ spec:
       nodeSelector:
         kubernetes.io/role: master
       containers:
-        - image: k8s.gcr.io/cluster-autoscaler:v1.2.0
+        - image: k8s.gcr.io/cluster-autoscaler:v1.2.2
           name: cluster-autoscaler
           resources:
             limits:
@@ -142,6 +142,9 @@ spec:
             - --cloud-provider=aws
             - --skip-nodes-with-local-storage=false
             - --expander=least-waste
+            - --scan-interval=60s
+            - --scale-down-delay-after-add=1m
+            - --scale-down-unneeded-time=1m
             - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,kubernetes.io/cluster/{{ cluster_name }}
           env:
             - name: AWS_REGION

--- a/deploy/ansible/roles/k8s_resources/templates/autoscaler.yaml.j2
+++ b/deploy/ansible/roles/k8s_resources/templates/autoscaler.yaml.j2
@@ -137,7 +137,7 @@ spec:
               memory: 300Mi
           command:
             - ./cluster-autoscaler
-            - --v=1
+            - --v=4
             - --stderrthreshold=info
             - --cloud-provider=aws
             - --skip-nodes-with-local-storage=false

--- a/deploy/ci-infra.Jenkinsfile
+++ b/deploy/ci-infra.Jenkinsfile
@@ -22,7 +22,7 @@ node {
                     [$class: 'GitParameterValue', name: 'GitBranch', value: params.GitBranch],
                     string(name: 'Profile', value: params.Profile),
                     string(name: 'LegionVersion', value: legionVersion),
-                    string(name: 'TestsTags', value: "core,k8s,aws"),
+                    string(name: 'TestsTags', value: "infra"),
                     booleanParam(name: 'DeployLegion', value: true),
                     booleanParam(name: 'CreateJenkinsTests', value: true),
                     booleanParam(name: 'UseRegressionTests', value: true),

--- a/examples/Vertical-Scaling/performance.Jenkinsfile
+++ b/examples/Vertical-Scaling/performance.Jenkinsfile
@@ -1,7 +1,7 @@
 node {
     def legion = load legion()
 
-    legion.pod(cpu: '7') {
+    legion.pod(ram: '12Gi') {
         stage('System info'){
             sh "df -h"
             sh "cat /proc/cpuinfo"

--- a/examples/Vertical-Scaling/performance.Jenkinsfile
+++ b/examples/Vertical-Scaling/performance.Jenkinsfile
@@ -1,7 +1,7 @@
 node {
     def legion = load legion()
 
-    legion.pod(ram: '10Gi') {
+    legion.pod(cpu: '7') {
         stage('System info'){
             sh "df -h"
             sh "cat /proc/cpuinfo"

--- a/examples/Vertical-Scaling/performance.Jenkinsfile
+++ b/examples/Vertical-Scaling/performance.Jenkinsfile
@@ -1,7 +1,7 @@
 node {
     def legion = load legion()
 
-    legion.pod(ram: '12Gi') {
+    legion.pod(cpu: '7') {
         stage('System info'){
             sh "df -h"
             sh "cat /proc/cpuinfo"

--- a/legion_test/legion_test/robot/k8s.py
+++ b/legion_test/legion_test/robot/k8s.py
@@ -267,7 +267,7 @@ class K8s:
         time.sleep(sleep)
 
         while True:
-            nodes_num = core_api.list_node().count()
+            nodes_num = len(core_api.list_node().items)
             elapsed = time.time() - start
             if nodes_num == expected_count:
                 print('Scaled node was successfully unscaled after {} seconds'

--- a/legion_test/legion_test/robot/k8s.py
+++ b/legion_test/legion_test/robot/k8s.py
@@ -245,7 +245,7 @@ class K8s:
         nodes = core_api.list_node().items
         return nodes
 
-    def wait_node_scale_down(self, expected_count, timeout=420, sleep=5):
+    def wait_node_scale_down(self, expected_count, timeout=600, sleep=10):
         """
         Wait finish of last job build
 

--- a/legion_test/legion_test/robot/k8s.py
+++ b/legion_test/legion_test/robot/k8s.py
@@ -245,7 +245,7 @@ class K8s:
         nodes = core_api.list_node().items
         return nodes
 
-    def wait_node_scale_down(self, expected_count, timeout=200, sleep=5):
+    def wait_node_scale_down(self, expected_count, timeout=420, sleep=5):
         """
         Wait finish of last job build
 

--- a/legion_test/legion_test/templates/jenkins_performance_job.tmpl
+++ b/legion_test/legion_test/templates/jenkins_performance_job.tmpl
@@ -48,8 +48,8 @@
       <configVersion>2</configVersion>
       <userRemoteConfigs>
         <hudson.plugins.git.UserRemoteConfig>
-          <url>${GitRepository}</url>
           <refspec>+refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/*</refspec>
+          <url>${GitRepository}</url>
           {% if GIT_ROOT_KEY %}
           <credentialsId>{{GIT_ROOT_KEY}}</credentialsId>
           {% endif %}

--- a/tests/robot/resources/keywords.robot
+++ b/tests/robot/resources/keywords.robot
@@ -236,6 +236,13 @@ Run predefined Jenkins jobs for enclave
     :FOR  ${model_name}  IN  @{JENKINS_JOBS}
     \    Run model jenkins Job  ${model_name}  ${enclave}
 
+Get cluster nodes and their count
+    [Arguments]    ${is_before}
+    @{cluster_nodes} =    Get cluster nodes
+    ${nodes_number} =     Get Length    ${cluster_nodes}
+    Run Keyword If   '${is_before}' == 'before'    Set Test Variable     ${NODES_COUNT_BEFORE}    ${nodes_number}
+    ...    ELSE      Set Test Variable     ${NODES_COUNT_AFTER}    ${nodes_number}
+
     # --------- TEMPLATE KEYWORDS SECTION -----------
 
 Check if component domain has been secured

--- a/tests/robot/tests/1_common/1.1_check_clusterwide.robot
+++ b/tests/robot/tests/1_common/1.1_check_clusterwide.robot
@@ -50,10 +50,23 @@ Check Nexus Components available
 #    List Should Contain Value               ${componentNames}           docker-hosted
 #    List Should Contain Value               ${componentNames}           raw
 
-
 Check enclave Grafana availability
     [Documentation]  Try to connect to Grafana in each enclave
     [Tags]  grafana  enclave
     :FOR    ${enclave}    IN    @{ENCLAVES}
     \  Connect to enclave Grafana     ${enclave}
 
+Check Vertical Scailing
+    [Documentation]  Runs "PERF TEST Vertical-Scaling" jenkins job to test vertical scailing
+    [Tags]  jenkins  model  scaling  infra
+    Get cluster nodes and their count    before
+
+    :FOR  ${enclave}    IN    @{ENCLAVES}
+    \  Connect to Jenkins endpoint
+        Run Jenkins job                                         PERF TEST Vertical-Scaling   Enclave=${enclave}
+        Wait Jenkins job                                        PERF TEST Vertical-Scaling   600
+        Last Jenkins job is successful                          PERF TEST Vertical-Scaling
+
+    Get cluster nodes and their count    after
+    Should Not Be Equal As Integers    ${NODES_COUNT_BEFORE}    ${NODES_COUNT_AFTER}
+    Wait node scale down           ${NODES_COUNT_BEFORE}

--- a/tests/robot/tests/2_jenkins_models/2.0_check_jenkins_models.robot
+++ b/tests/robot/tests/2_jenkins_models/2.0_check_jenkins_models.robot
@@ -46,8 +46,14 @@ Checking property update callback
 Check Vertical Scailing
     [Documentation]  Runs "PERF TEST Vertical-Scaling" jenkins job to test vertical scailing
     [Tags]  jenkins  model  scaling
+    Get cluster nodes and their count    before
+
     :FOR  ${enclave}    IN    @{ENCLAVES}
     \  Connect to Jenkins endpoint
         Run Jenkins job                                         PERF TEST Vertical-Scaling   Enclave=${enclave}
         Wait Jenkins job                                        PERF TEST Vertical-Scaling   600
         Last Jenkins job is successful                          PERF TEST Vertical-Scaling
+
+    Get cluster nodes and their count    after
+    Should Be Equal As Integers    ${NODES_COUNT_BEFORE}    ${NODES_COUNT_AFTER}
+    Wait node scale down           ${NODES_COUNT_BEFORE}

--- a/tests/robot/tests/2_jenkins_models/2.0_check_jenkins_models.robot
+++ b/tests/robot/tests/2_jenkins_models/2.0_check_jenkins_models.robot
@@ -55,5 +55,5 @@ Check Vertical Scailing
         Last Jenkins job is successful                          PERF TEST Vertical-Scaling
 
     Get cluster nodes and their count    after
-    Should Be Equal As Integers    ${NODES_COUNT_BEFORE}    ${NODES_COUNT_AFTER}
+    Should Not Be Equal As Integers    ${NODES_COUNT_BEFORE}    ${NODES_COUNT_AFTER}
     Wait node scale down           ${NODES_COUNT_BEFORE}

--- a/tests/robot/tests/2_jenkins_models/2.0_check_jenkins_models.robot
+++ b/tests/robot/tests/2_jenkins_models/2.0_check_jenkins_models.robot
@@ -42,18 +42,3 @@ Checking property update callback
 
     Ensure model property has been updated  ${model_id}  ${model_version}  ${edge}  ${TOKEN}  ${MODEL_WITH_PROPS_PROP}  2
     Ensure model API call result field is correct  ${model_id}  ${model_version}  ${edge}  ${TOKEN}  ${MODEL_WITH_PROPS_ENDPOINT}  result  300   a=1  b=2
-
-Check Vertical Scailing
-    [Documentation]  Runs "PERF TEST Vertical-Scaling" jenkins job to test vertical scailing
-    [Tags]  jenkins  model  scaling
-    Get cluster nodes and their count    before
-
-    :FOR  ${enclave}    IN    @{ENCLAVES}
-    \  Connect to Jenkins endpoint
-        Run Jenkins job                                         PERF TEST Vertical-Scaling   Enclave=${enclave}
-        Wait Jenkins job                                        PERF TEST Vertical-Scaling   600
-        Last Jenkins job is successful                          PERF TEST Vertical-Scaling
-
-    Get cluster nodes and their count    after
-    Should Not Be Equal As Integers    ${NODES_COUNT_BEFORE}    ${NODES_COUNT_AFTER}
-    Wait node scale down           ${NODES_COUNT_BEFORE}


### PR DESCRIPTION
Now we get nodes count before test -> 
request resources for new node creation -> 
check that new node was created -> 
check that new node was scaled down (7 min timeout, every 5 sec check)