### PR TITLE
[#549] Disable Edge home page in Nginx config based on profile parameter

### DIFF
--- a/deploy/ansible/roles/legion_enclave/templates/legion-values.yaml.j2
+++ b/deploy/ansible/roles/legion_enclave/templates/legion-values.yaml.j2
@@ -28,7 +28,8 @@ grafana:
 edge:
   enabled: true
   replicas: 2
-  image: 
+  enableHomePage: {% if hide_edge_page == true %}false{% else %}true{% endif %}
+  image:
     repository: "{{ docker_repo }}/k8s-edge"
     tag: "{{ legion_version }}"
 

--- a/deploy/ansible/roles/legion_enclave/templates/legion-values.yaml.j2
+++ b/deploy/ansible/roles/legion_enclave/templates/legion-values.yaml.j2
@@ -28,7 +28,7 @@ grafana:
 edge:
   enabled: true
   replicas: 2
-  enableHomePage: {% if hide_edge_page == true %}false{% else %}true{% endif %}
+  enableHomePage: {% if (hide_edge_page | default('false')) == true %}false{% else %}true{% endif %}
 
   image:
     repository: "{{ docker_repo }}/k8s-edge"

--- a/deploy/ansible/roles/legion_enclave/templates/legion-values.yaml.j2
+++ b/deploy/ansible/roles/legion_enclave/templates/legion-values.yaml.j2
@@ -29,6 +29,7 @@ edge:
   enabled: true
   replicas: 2
   enableHomePage: {% if hide_edge_page == true %}false{% else %}true{% endif %}
+
   image:
     repository: "{{ docker_repo }}/k8s-edge"
     tag: "{{ legion_version }}"

--- a/deploy/helms/legion/templates/edge/edge-server.yaml
+++ b/deploy/helms/legion/templates/edge/edge-server.yaml
@@ -47,7 +47,7 @@ spec:
           protocol: TCP
         livenessProbe:
           httpGet:
-            path: /
+            path: /healthcheck
             port: 80
           initialDelaySeconds: 10
           periodSeconds: 3

--- a/deploy/helms/legion/templates/edge/edge-server.yaml
+++ b/deploy/helms/legion/templates/edge/edge-server.yaml
@@ -39,6 +39,8 @@ spec:
             secretKeyRef:
               name: "{{ .Release.Name }}-jwt-config"
               key: "jwt.secret"
+        - name: ENABLE_HOME_PAGE
+          value: "{{ .Values.edge.enableHomePage }}"
         ports:
         - containerPort: 80
           name: api

--- a/deploy/helms/legion/values.yaml
+++ b/deploy/helms/legion/values.yaml
@@ -29,6 +29,7 @@ edi:
 edge:
   enabled: true
   replicas: 2
+  enableHomePage: true
   image:
     repository: "legion/k8s-edge"
     tag: "latest"

--- a/deploy/profiles/profiles_template.yaml
+++ b/deploy/profiles/profiles_template.yaml
@@ -89,4 +89,4 @@ collector:    # event collector configuration
   bucket: ~ # bucket for event collector data
   region: ~ # bucket region
 
-hide_edge_page: ~ # 'true' - Edge Home page is hidden
+# hide_edge_page: ~ # (Optional) 'false' - Edge home page os visible (default value)

--- a/deploy/profiles/profiles_template.yaml
+++ b/deploy/profiles/profiles_template.yaml
@@ -88,3 +88,5 @@ collector:    # event collector configuration
   replicas: ~
   bucket: ~ # bucket for event collector data
   region: ~ # bucket region
+
+hide_edge_page: ~ # 'true' - Edge Home page is hidden

--- a/k8s/edge/nginx.conf.ltmpl
+++ b/k8s/edge/nginx.conf.ltmpl
@@ -62,10 +62,14 @@ http{
 
     chunked_transfer_encoding on;
 
-    {% if environ['ENABLE_HOME_PAGE'] == 'true' %}
     # Root location
+    {% if environ['ENABLE_HOME_PAGE'] == 'true' %}
     location / {
       root /static;
+    }
+    {% else %}
+    location / {
+      return 200;
     }
     {% endif %}
 

--- a/k8s/edge/nginx.conf.ltmpl
+++ b/k8s/edge/nginx.conf.ltmpl
@@ -14,6 +14,7 @@
 #    limitations under the License.
 #
 {{ load_module('legion.template_plugins.enclave_models_monitor') }}
+{{ load_module('legion.template_plugins.environment_variables_provider') }}
 
 env JWT_SECRET;
 
@@ -61,10 +62,12 @@ http{
 
     chunked_transfer_encoding on;
 
+    {% if environ['ENABLE_HOME_PAGE'] == 'true' %}
     # Root location
     location / {
       root /static;
     }
+    {% endif %}
 
     # Models API
     {% for model_endpoint in models %}

--- a/k8s/edge/nginx.conf.ltmpl
+++ b/k8s/edge/nginx.conf.ltmpl
@@ -62,6 +62,10 @@ http{
 
     chunked_transfer_encoding on;
 
+    location /healthcheck {
+      return 200;
+    }
+
     # Root location
     {% if environ['ENABLE_HOME_PAGE'] == 'true' %}
     location / {
@@ -69,7 +73,7 @@ http{
     }
     {% else %}
     location / {
-      return 200;
+      return 404;
     }
     {% endif %}
 

--- a/legion/legion/template_plugins/os_environ.py
+++ b/legion/legion/template_plugins/os_environ.py
@@ -29,6 +29,5 @@ async def environment_variables_provider(template_system):
     :param template_system: Object, that contains 'render' callback function
     :return: None
     """
-
     LOGGER.info('Render template with environ variables')
     template_system.render(environ=os.environ)

--- a/legion/legion/template_plugins/os_environ.py
+++ b/legion/legion/template_plugins/os_environ.py
@@ -14,8 +14,21 @@
 #    limitations under the License.
 #
 """
-legion template plugins
+Environment variables provider for Legion Template
 """
-from .enclave import enclave_models_monitor
-from .io import file_change_monitor
-from .os_environ import environment_variables_provider
+import logging
+import os
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def environment_variables_provider(template_system):
+    """
+    Update template context with environment variables values
+
+    :param template_system: Object, that contains 'render' callback function
+    :return: None
+    """
+
+    LOGGER.info('Render template with environ variables')
+    template_system.render(environ=os.environ)


### PR DESCRIPTION
This PR closes #549 
1. Passed environment variable to Edge pod based on property in profile file
2. Created **os_environ** template plugin
3. Updated nginx.conf template, to read **ENABLE_HOME_PAGE** environment variable
4. Changed Edge liveness probe, because edge home page returns 404 when home page is disabled