### PR TITLE
[#590] Light alpine image speeds up scaling test

### DIFF
--- a/examples/Vertical-Scaling/performance.Jenkinsfile
+++ b/examples/Vertical-Scaling/performance.Jenkinsfile
@@ -1,7 +1,7 @@
 node {
     def legion = load legion()
 
-    legion.pod(cpu: '7') {
+    legion.pod(cpu: '7', image: 'alpine:3.8') {
         stage('System info'){
             sh "df -h"
             sh "cat /proc/cpuinfo"


### PR DESCRIPTION
Vertical scaling test execution speed has been increased from 15 to 7 minutes.