### PR TITLE
[#270] Fixed S3Hook to work without connection_id

### DIFF
--- a/deploy/ansible/roles/legion_enclave/templates/airflow-values.yaml.j2
+++ b/deploy/ansible/roles/legion_enclave/templates/airflow-values.yaml.j2
@@ -30,7 +30,7 @@ core:
   logging_level: info
   remote_logging: true
   remote_base_log_folder: "{{ airflow_s3_logs_url }}"
-  remote_log_conn_id: s3_conn
+  remote_log_conn_id:
 
 webserver:
   worker_refresh_interval: 10

--- a/deploy/helms/airflow/templates/configuration.yaml
+++ b/deploy/helms/airflow/templates/configuration.yaml
@@ -25,7 +25,9 @@ s3_root_path = {{ .Values.storage.s3_root_path }}
 logging_config_class = log_config.DEFAULT_LOGGING_CONFIG
 remote_logging = {{ .Values.core.remote_logging }}
 remote_base_log_folder = {{ .Values.core.remote_base_log_folder }}
+{{ if .Values.core.remote_log_conn_id }}
 remote_log_conn_id = {{ .Values.core.remote_log_conn_id }}
+{{ end }}
 # Use server-side encryption for logs stored in S3
 encrypt_s3_logs = {{ .Values.core.encrypt_s3_logs }}
 # deprecated option for remote log storage, use remote_base_log_folder instead!

--- a/legion_airflow/legion_airflow/hooks/s3_handler.py
+++ b/legion_airflow/legion_airflow/hooks/s3_handler.py
@@ -24,13 +24,17 @@ class S3TaskHandlerWithIAM(S3TaskHandler):
     """
 
     def _build_hook(self):
+        remote_conn_id = conf.conf.get('core', 'REMOTE_LOG_CONN_ID')
         try:
             from legion_airflow.hooks.s3_hook import S3Hook
-            return S3Hook()
+            if remote_conn_id:
+                return S3Hook(remote_conn_id)
+            else:
+                return S3Hook()
         except Exception as e:
             self.log.error(
-                'Could not create an S3Hook connection. '
+                'Could not create an S3Hook with connection id "%s". '
                 'Please make sure that airflow[s3] is installed and '
-                'the S3 connection exists.'
+                'the S3 connection exists.', remote_conn_id
             )
             raise

--- a/legion_airflow/legion_airflow/hooks/s3_handler.py
+++ b/legion_airflow/legion_airflow/hooks/s3_handler.py
@@ -24,14 +24,13 @@ class S3TaskHandlerWithIAM(S3TaskHandler):
     """
 
     def _build_hook(self):
-        remote_conn_id = conf.conf.get('core', 'REMOTE_LOG_CONN_ID')
         try:
             from legion_airflow.hooks.s3_hook import S3Hook
-            return S3Hook(remote_conn_id)
+            return S3Hook()
         except Exception as e:
             self.log.error(
-                'Could not create an S3Hook with connection id "%s". '
+                'Could not create an S3Hook connection. '
                 'Please make sure that airflow[s3] is installed and '
-                'the S3 connection exists.', remote_conn_id
+                'the S3 connection exists.'
             )
             raise

--- a/legion_airflow/legion_airflow/hooks/s3_hook.py
+++ b/legion_airflow/legion_airflow/hooks/s3_hook.py
@@ -31,7 +31,7 @@ class S3Hook(K8SBaseHook):
     STOP_FILE_POSTFIX = '.STOP'
     STOP_FILE_NAME = 'STOP'
 
-    def __init__(self, conn_id: str, *args, **kwargs):
+    def __init__(self, conn_id: str = None, *args, **kwargs):
         """
         Initialize S3Hook.
 
@@ -47,10 +47,16 @@ class S3Hook(K8SBaseHook):
         self._args = args
         self._kwargs = kwargs
         # get the connection parameters
-        self.connection = self.get_connection(conn_id)
-        self.extras = self.connection.extra_dejson
-        self.aws_access_key_id = self.extras.get('aws_access_key_id', None)
-        self.aws_secret_access_key = self.extras.get('aws_secret_access_key', None)
+
+        if conn_id is not None:
+            self.connection = self.get_connection(conn_id)
+            self.extras = self.connection.extra_dejson
+            self.aws_access_key_id = self.extras.get('aws_access_key_id', None)
+            self.aws_secret_access_key = self.extras.get('aws_secret_access_key', None)
+        else:
+            self.aws_access_key_id = None
+            self.aws_secret_access_key = None
+
         try:
             self.s3_root_path = conf.get('core', 's3_root_path')
         except AirflowConfigException:


### PR DESCRIPTION
This PR closes #270 and fixes inaccessible logs in Airflow Web.