### PR TITLE
[#666] Rename version to model_version

### DIFF
--- a/k8s/edge/nginx.conf.ltmpl
+++ b/k8s/edge/nginx.conf.ltmpl
@@ -92,7 +92,7 @@ http {
             local jwt = require("nginx-jwt")
             jwt.auth({
                 model_id=function (val) return jwt.table_contains(val, model_id) end,
-                version=function (val) return jwt.table_contains(val, model_version) end
+                model_version=function (val) return jwt.table_contains(val, model_version) end
             })
             local blacklisted_tokens = require "blacklisted_tokens"
             blacklisted_tokens.check_token()

--- a/k8s/edge/nginx.conf.ltmpl
+++ b/k8s/edge/nginx.conf.ltmpl
@@ -144,7 +144,7 @@ http {
             local jwt = require("nginx-jwt")
             jwt.auth({
                 model_id=function (val) return jwt.table_contains(val, "{{ model_endpoint.model_service.id }}") end,
-                version=function (val) return jwt.table_contains(val, "{{ model_endpoint.model_service.version }}") end
+                model_version=function (val) return jwt.table_contains(val, "{{ model_endpoint.model_service.version }}") end
             })
             local blacklisted_tokens = require "blacklisted_tokens"
             blacklisted_tokens.check_token()

--- a/legion/legion/edi/server.py
+++ b/legion/legion/edi/server.py
@@ -322,9 +322,9 @@ def info():
 @blueprint.route(build_blueprint_url(EDI_GENERATE_TOKEN), methods=['POST'])
 @legion.http.provide_json_response
 @legion.http.authenticate(authenticate)
-@legion.http.populate_fields(model_id=str, version=str)
-@legion.http.requested_fields('model_id', 'version')
-def generate_token(model_id, version):
+@legion.http.populate_fields(model_id=str, model_version=str)
+@legion.http.requested_fields('model_id', 'model_version')
+def generate_token(model_id, model_version):
     """
     Generate JWT token
 
@@ -341,8 +341,10 @@ def generate_token(model_id, version):
     if not jwt_exp_date or jwt_exp_date < datetime.now():
         jwt_life_length = timedelta(minutes=int(app.config['JWT_CONFIG']['jwt.length.minutes']))
         jwt_exp_date = datetime.utcnow() + jwt_life_length
-    token = jwt.encode({'exp': jwt_exp_date, 'model_id': [model_id],
-                        'version': [version]}, jwt_secret, algorithm='HS256').decode('utf-8')
+    token = jwt.encode({'exp': jwt_exp_date,
+                        'model_id': [model_id],
+                        'model_version': [model_version]},
+                       jwt_secret, algorithm='HS256').decode('utf-8')
     return {'token': token, 'exp': jwt_exp_date}
 
 

--- a/legion/legion/external/edi.py
+++ b/legion/legion/external/edi.py
@@ -235,17 +235,19 @@ class EdiClient:
 
         return self.parse_deployments(self._query(legion.edi.server.EDI_SCALE, action='POST', payload=payload))
 
-    def get_token(self, model_id, version):
+    def get_token(self, model_id, model_version):
         """
         Get API token
 
-        :param version: (Optional) model version
-        :type version: str
+        :param model_id: model ID
+        :type model_id: str
+        :param model_version: model version
+        :type model_version: str
         :return: str -- return API Token
         """
         payload = {}
         payload['model_id'] = model_id
-        payload['version'] = version
+        payload['model_version'] = model_version
 
         response = self._query(legion.edi.server.EDI_GENERATE_TOKEN, action='POST', payload=payload)
         if response and 'token' in response:

--- a/tests/robot/resources/keywords.robot
+++ b/tests/robot/resources/keywords.robot
@@ -177,11 +177,11 @@ Build enclave EDGE URL
 Get token from EDI
     [Documentation]  get token from EDI for the EDGE session
     [Arguments]     ${enclave}   ${model_id}   ${model_version}
-    &{data} =    Create Dictionary    model_id=${model_id}    version=${model_version}
-    &{resp} =       Execute post request    ${HOST_PROTOCOL}://edi-${enclave}.${HOST_BASE_DOMAIN}/api/1.0/generate_token    data=${data}
+    &{data} =             Create Dictionary    model_id=${model_id}    model_version=${model_version}
+    &{resp} =             Execute post request    ${HOST_PROTOCOL}://edi-${enclave}.${HOST_BASE_DOMAIN}/api/1.0/generate_token    data=${data}
     Log                   ${resp["text"]}
     Should not be empty   ${resp}
-    &{token} =      Evaluate    json.loads('''${resp["text"]}''')    json
+    &{token} =  Evaluate  json.loads('''${resp["text"]}''')    json
     Log                   ${token}
     Set Suite Variable    ${TOKEN}    ${token['token']}
 

--- a/tests/robot/tests/2_jenkins_models/2.0_check_jenkins_models.robot
+++ b/tests/robot/tests/2_jenkins_models/2.0_check_jenkins_models.robot
@@ -25,7 +25,7 @@ Checking property update callback
     [Tags]  jenkins  models  enclave  props  apps
     Connect to Jenkins endpoint
     ${model_id}    ${model_version} =   Test model pipeline result   ${MODEL_WITH_PROPS}   ${MODEL_TEST_ENCLAVE}
-    Log   Model with id = ${model_id} and version = ${model_version} has been deployed
+    Log   Model with id = ${model_id} and model_version = ${model_version} has been deployed
     ${edge}=        Build enclave EDGE URL  ${MODEL_TEST_ENCLAVE}
                     Get token from EDI      ${MODEL_TEST_ENCLAVE}   ${model_id}    ${model_version}
 

--- a/tests/robot/tests/3_edi_one_model/3.0_check_edi_one_model.robot
+++ b/tests/robot/tests/3_edi_one_model/3.0_check_edi_one_model.robot
@@ -46,13 +46,13 @@ Get token from EDI without version parameter
     &{json} =   Evaluate    json.loads('''${resp["text"]}''')    json
     Log          ${json}
     ${items} = 	 Get Dictionary Items    ${json}
-    Should be equal as strings   ${items}    ['error', True, 'exception', 'Requested field version is not set']
+    Should be equal as strings   ${items}    ['error', True, 'exception', 'Requested field model_version is not set']
 
 Get token from EDI without model_id parameter
     [Documentation]  Try to get token from EDI without model_id parameter
     [Setup]   NONE
     [Tags]  edi  cli  enclave  edi_token
-    &{data} =    Create Dictionary    version=${TEST_MODEL_3_VERSION}
+    &{data} =    Create Dictionary    model_version=${TEST_MODEL_3_VERSION}
     &{resp} =    Execute post request    ${HOST_PROTOCOL}://edi-${MODEL_TEST_ENCLAVE}.${HOST_BASE_DOMAIN}/api/1.0/generate_token    data=${data}
     Log          ${resp}
     Should not be empty   ${resp}


### PR DESCRIPTION
This closes #666.
This renames `version` to `model_version` in EDI `generate_token` endpoint