### PR TITLE
[#656] Keep DataFrame column order for export_df

### DIFF
--- a/legion/legion/model/client.py
+++ b/legion/legion/model/client.py
@@ -197,7 +197,7 @@ class ModelClient:
         Build POST and FILE fields for request due their type
 
         :param parameters: dict -- invoke parameters
-        :return: tuple[dict, dict] -- POST and FILE dictionaries in tuple
+        :return: tuple[list, dict] -- POST list and FILE dictionary in tuple
         """
         post_fields_dict = {k: v for (k, v) in parameters.items() if not isinstance(v, bytes)}
         post_files = {k: v for (k, v) in parameters.items() if isinstance(v, bytes)}

--- a/legion/legion/model/types.py
+++ b/legion/legion/model/types.py
@@ -411,8 +411,7 @@ def build_df(columns_map, input_values, return_dict=False):
     if return_dict:
         return values
 
-    data_frame = pd.DataFrame([values])
-    data_frame = data_frame[list(columns_map.keys())]
+    data_frame = pd.DataFrame([values], columns=columns_map.keys())
     data_frame = data_frame.astype(types)
     return data_frame
 

--- a/legion/legion/model/types.py
+++ b/legion/legion/model/types.py
@@ -412,6 +412,7 @@ def build_df(columns_map, input_values, return_dict=False):
         return values
 
     data_frame = pd.DataFrame([values])
+    data_frame = data_frame[list(columns_map.keys())]
     data_frame = data_frame.astype(types)
     return data_frame
 

--- a/legion/tests/test_deploy.py
+++ b/legion/tests/test_deploy.py
@@ -241,6 +241,18 @@ class TestDeploy(unittest2.TestCase):
 
             self.assertEqual(context.client.invoke(x=1)['code'], 0, 'invalid invocation result')
 
+    def test_columns_ordering(self):
+        with ModelDockerBuilderContainerContext() as context:
+            context.copy_model('columns_model')
+            model_id, model_version, model_file, _ = context.execute_model()
+            self.assertEqual(model_id, 'columns-model', 'incorrect model id')
+            self.assertEqual(model_version, '1.0', 'incorrect model version')
+            image_id, _ = context.build_model_container(model_file)
+
+        with ModelLocalContainerExecutionContext(image_id) as context:
+            self.assertEqual(context.client.invoke(c=3, b=2, a=1)['result'],
+                             ['c', 'b', 'a'], 'invalid invocation result')
+
 
 if __name__ == '__main__':
     unittest2.main()

--- a/legion/tests/test_deploy.py
+++ b/legion/tests/test_deploy.py
@@ -250,7 +250,7 @@ class TestDeploy(unittest2.TestCase):
             image_id, _ = context.build_model_container(model_file)
 
         with ModelLocalContainerExecutionContext(image_id) as context:
-            self.assertEqual(context.client.invoke(c=3, b=2, a=1)['result'],
+            self.assertEqual(context.client.invoke(a=3, b=2, c=1)['result'],
                              ['c', 'b', 'a'], 'invalid invocation result')
 
 

--- a/legion/tests/test_models/columns_model/run.py
+++ b/legion/tests/test_models/columns_model/run.py
@@ -1,0 +1,15 @@
+import pandas as pd
+
+import legion.model
+
+
+legion.model.init('columns model', '1.0')
+
+
+def calculate(x):
+    return list(x.keys())
+
+
+legion.model.export_df(lambda x: {'result': calculate(x)},
+                       pd.DataFrame({'c': [3], 'b': [2], 'a': [1]}))
+legion.model.save('abc.model')


### PR DESCRIPTION
* Added DataFrame column ordering in `build_df` function based on passed `columns_map` order.
* Added test for DataFrame column ordering check
* Fixed docstring for `_prepare_invoke_request`