### PR TITLE
[#714] decrease number of requests to grafana and increase cpu

### DIFF
--- a/deploy/helms/legion-core/templates/metrics/grafana.yaml
+++ b/deploy/helms/legion-core/templates/metrics/grafana.yaml
@@ -23,10 +23,10 @@ spec:
         imagePullPolicy: "{{ .Values.grafana.image.pullPolicy }}"
         resources:
           requests:
-            cpu: "50m"
+            cpu: "250m"
             memory: "128Mi"
           limits:
-            cpu: "200m"
+            cpu: "500m"
             memory: "512Mi"
         env:
         - name: GF_SECURITY_ADMIN_PASSWORD

--- a/deploy/helms/legion/templates/metrics/grafana.yaml
+++ b/deploy/helms/legion/templates/metrics/grafana.yaml
@@ -23,10 +23,10 @@ spec:
         imagePullPolicy: "{{ .Values.grafana.image.pullPolicy }}"
         resources:
           requests:
-            cpu: "50m"
+            cpu: "250m"
             memory: "128Mi"
           limits:
-            cpu: "100m"
+            cpu: "500m"
             memory: "512Mi"
         env:
         - name: GF_SECURITY_ADMIN_PASSWORD

--- a/legion/legion/edi/server.py
+++ b/legion/legion/edi/server.py
@@ -176,10 +176,8 @@ def deploy(image, model_iam_role=None, count=1, livenesstimeout=2, readinesstime
         if app.config['REGISTER_ON_GRAFANA']:
             LOGGER.info('Registering dashboard on Grafana for model (id={}, version={})'
                         .format(model_service.id, model_service.version))
-            if not app.config['GRAFANA_CLIENT'].is_dashboard_exists(model_service.id, model_service.version):
-                app.config['GRAFANA_CLIENT'].create_dashboard_for_model(model_service.id, model_service.version)
-            else:
-                LOGGER.info('Registration on Grafana has been skipped - dashboard exists')
+
+            app.config['GRAFANA_CLIENT'].create_dashboard_for_model(model_service.id, model_service.version)
         else:
             LOGGER.info('Registration on Grafana has been skipped - disabled in configuration')
 
@@ -229,12 +227,11 @@ def undeploy(model, version=None, grace_period=0, ignore_not_found=False):
             other_versions_exist = len(app.config['ENCLAVE'].get_models(model_service.id)) > 1
             LOGGER.info('Removing model\'s dashboard from Grafana (id={}, version={})'
                         .format(model_service.id, model_service.version))
-            if app.config['GRAFANA_CLIENT'].is_dashboard_exists(model_service.id, model_service.version) \
-                    and not other_versions_exist:
-                app.config['GRAFANA_CLIENT'].remove_dashboard_for_model(model_service.id,
-                                                                        model_service.version)
+
+            if not other_versions_exist:
+                app.config['GRAFANA_CLIENT'].remove_dashboard_for_model(model_service.id, model_service.version)
             else:
-                LOGGER.info('Removing model\'s dashboard from Grafana has been skipped')
+                LOGGER.info('Removing model\'s dashboard from Grafana has been skipped - there are other model')
         else:
             LOGGER.info('Removing model\'s dashboard from Grafana has been skipped - disabled in configuration')
 


### PR DESCRIPTION
By default grafana uses the sqlite database. Many concurrent
connections can be issue. For example, deletion of a dashboard response
404 status code, when the dashboard presents.

PR fixes this comment https://github.com/legion-platform/legion/issues/714#issuecomment-451081771