### PR TITLE
[#714] Stabilization of airflow tests

### DIFF
--- a/deploy/helms/airflow/templates/flower.yaml
+++ b/deploy/helms/airflow/templates/flower.yaml
@@ -16,7 +16,7 @@ spec:
       port: 5555
       targetPort: flower
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ .Release.Name }}-flower"
@@ -25,11 +25,17 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: "{{ .Release.Name }}-flower"
+    app: "{{ .Release.Name }}-airflow-flower"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      component: "{{ .Release.Name }}-flower"
+      app: "{{ .Release.Name }}-airflow-flower"
   template:
     metadata:
       labels:
+        component: "{{ .Release.Name }}-flower"
         app: "{{ .Release.Name }}-airflow-flower"
     spec:
       restartPolicy: Always

--- a/deploy/helms/airflow/templates/mq.yaml
+++ b/deploy/helms/airflow/templates/mq.yaml
@@ -16,7 +16,7 @@ spec:
       port: 6379
       targetPort: node
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ .Release.Name }}-redis"
@@ -25,11 +25,17 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: "{{ .Release.Name }}-redis"
+    app: "{{ .Release.Name }}-redis"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      component: "{{ .Release.Name }}-redis"
+      app: "{{ .Release.Name }}-redis"
   template:
     metadata:
       labels:
+        component: "{{ .Release.Name }}-redis"
         app: "{{ .Release.Name }}-redis"
     spec:
       restartPolicy: Always

--- a/deploy/helms/airflow/templates/scheduler.yaml
+++ b/deploy/helms/airflow/templates/scheduler.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ .Release.Name }}-scheduler"
@@ -7,13 +7,19 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: "{{ .Release.Name }}-scheduler"
+    app: "{{ .Release.Name }}-airflow-scheduler"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      component: "{{ .Release.Name }}-scheduler"
+      app: "{{ .Release.Name }}-airflow-scheduler"
   template:
     metadata:
       annotations:
         iam.amazonaws.com/role: "{{ .Values.clusterName }}-{{ .Values.enclave }}-airflow-role"
       labels:
+        component: "{{ .Release.Name }}-scheduler"
         app: "{{ .Release.Name }}-airflow-scheduler"
     spec:
       restartPolicy: Always

--- a/deploy/helms/airflow/templates/web.yaml
+++ b/deploy/helms/airflow/templates/web.yaml
@@ -16,7 +16,7 @@ spec:
       port: 8080
       targetPort: web
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ .Release.Name }}-web"
@@ -25,13 +25,19 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: "{{ .Release.Name }}-web"
+    app: "{{ .Release.Name }}-airflow-web"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      component: "{{ .Release.Name }}-web"
+      app: "{{ .Release.Name }}-airflow-web"
   template:
     metadata:
       annotations:
         iam.amazonaws.com/role: "{{ .Values.clusterName }}-{{ .Values.enclave }}-airflow-role"
       labels:
+        component: "{{ .Release.Name }}-web"
         app: "{{ .Release.Name }}-airflow-web"
     spec:
       restartPolicy: Always
@@ -82,6 +88,7 @@ spec:
             port: 8080
           initialDelaySeconds: 60
           periodSeconds: 5
+          failureThreshold: 12
           timeoutSeconds: 10
         readinessProbe:
           httpGet:
@@ -89,6 +96,7 @@ spec:
             port: 8080
           initialDelaySeconds: 60
           periodSeconds: 5
+          failureThreshold: 24
           timeoutSeconds: 10
       volumes:
       - name: airflow-config-dir

--- a/deploy/helms/airflow/templates/worker.yaml
+++ b/deploy/helms/airflow/templates/worker.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ .Release.Name }}-worker"
@@ -7,13 +7,19 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: "{{ .Release.Name }}-worker"
+    app: "{{ .Release.Name }}-airflow-worker"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      component: "{{ .Release.Name }}-worker"
+      app: "{{ .Release.Name }}-airflow-worker"
   template:
     metadata:
       annotations:
         iam.amazonaws.com/role: "{{ .Values.clusterName }}-{{ .Values.enclave }}-airflow-role"
       labels:
+        component: "{{ .Release.Name }}-worker"
         app: "{{ .Release.Name }}-airflow-worker"
     spec:
       serviceAccountName: "{{ .Release.Name }}-airflow-worker"


### PR DESCRIPTION
Increase failure threshold and replace apiVersion of airflow
deployment. `--wait` option doesn't work with Deployment extensions/v1beta1

PR fixes this comment https://github.com/legion-platform/legion/issues/714#issuecomment-451082905

Old deploy: https://cc.epm.kharlamov.biz/jenkins/job/Deploy_Legion_Release/255/consoleFull
```
TASK [legion_enclave : Install airflow chart] **********************************
changed: [localhost] => {.... "delta": "0:00:03.660973"
...
DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
airflow-company-a-flower     1        1        1           0          2s
airflow-company-a-redis      1        1        1           0          2s
airflow-company-a-scheduler  1        1        1           0          2s
airflow-company-a-web        1        1        1           0          2s
airflow-company-a-worker     1        1        1           0          2s
```

Deploy with fix: https://cc.epm.kharlamov.biz/jenkins/job/Deploy_Legion_Release/260/consoleFull
```
TASK [legion_enclave : Install airflow chart] **********************************
changed: [localhost] => {"delta": "0:01:07.493770"
...
DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
airflow-company-a-flower     1        1        1           1          1m
airflow-company-a-redis      1        1        1           1          1m
airflow-company-a-scheduler  1        1        1           1          1m
airflow-company-a-web        1        1        1           1          1m
airflow-company-a-worker     1        1        1           1          1m
```