### PR TITLE
[#714] Change to 60min delay in metrics requests

### DIFF
--- a/legion_test/legion_test/robot/grafana.py
+++ b/legion_test/legion_test/robot/grafana.py
@@ -116,7 +116,7 @@ class Grafana:
 
         payload = {
             'target': target,
-            'from': '-5min',
+            'from': '-60min',
             'until': 'now',
             'format': 'json',
             'cacheTimeout': 0,


### PR DESCRIPTION
This updates #714 