### PR TITLE
[714] Fixed hardcoded `from` parameter in the request to graphite

### DIFF
--- a/legion_test/legion_test/robot/grafana.py
+++ b/legion_test/legion_test/robot/grafana.py
@@ -16,6 +16,8 @@
 """
 Robot test library - grafana
 """
+import time
+
 from legion_test.grafana import GrafanaClient
 from legion_test.utils import normalize_name, wait_until
 from legion_test.robot.dex_client import get_session_cookies
@@ -27,7 +29,7 @@ class Grafana:
     Grafana client for robot tests
     """
 
-    ROBOT_LIBRARY_SCOPE = 'TEST SUITE'
+    ROBOT_LIBRARY_SCOPE = 'GLOBAL'
 
     def __init__(self):
         """
@@ -37,6 +39,7 @@ class Grafana:
         self._user = None  # type: str
         self._password = None  # type: str
         self._client = None  # type: legion_test.grafana.GrafanaClient
+        self._start_time = time.time()
 
     def connect_to_grafana(self, domain, user, password):
         """
@@ -116,7 +119,8 @@ class Grafana:
 
         payload = {
             'target': target,
-            'from': '-60min',
+            # Add 10 seconds to cover a corner case
+            'from': '-{}s'.format(int(time.time() - self._start_time) + 10),
             'until': 'now',
             'format': 'json',
             'cacheTimeout': 0,
@@ -124,6 +128,7 @@ class Grafana:
         }
 
         response = requests.post(url, data=payload, headers=headers, auth=auth, cookies=get_session_cookies())
+        print('Current time: {}. Start time: {}. Payload: {}'.format(time.time(), self._start_time, payload))
         print('Loading {} metrics. Data: {}'.format(target, response.text))
 
         return response.json()


### PR DESCRIPTION
We save start time of test suite in the grafana library to calculate
`from` parameter later.