### PR TITLE
[#673] Test coverage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -484,18 +484,33 @@ EOL
                                     --with-coverage \
                                     --cover-package legion \
                                     --with-xunitmp \
+                                    --cover-xml \
                                     --cover-html \
                                     --logging-level DEBUG \
                                     -v || true
 
                                 cd -
                                 cp /src/legion/nosetests.xml legion/nosetests.xml
-                                tar -czf legion/legion_coverage_${Globals.buildVersion}.tar.gz /src/legion/cover
+                                cp /src/legion/coverage.xml legion/coverage.xml
+                                cp -r /src/legion/cover legion/cover
                                 """
-                                /// Parse nose tests results
-                                junit 'legion/nosetests.xml'
 
-                                archiveArtifacts artifacts: "legion/legion_coverage_${Globals.buildVersion}.tar.gz"
+                                junit 'legion/nosetests.xml'
+                                cobertura coberturaReportFile: 'legion/coverage.xml'
+                                publishHTML (target: [
+                                  allowMissing: false,
+                                  alwaysLinkToLastBuild: false,
+                                  keepAll: true,
+                                  reportDir: 'legion/cover',
+                                  reportFiles: 'index.html',
+                                  reportName: "Test Coverage Report"
+                                ])
+
+                                sh """
+                                    rm -rf legion/nosetests.xml
+                                    rm -rf legion/coverage.xml
+                                    rm -rf legion/cover
+                                """
                             }
                         }
                     }


### PR DESCRIPTION
Add the Cobertura plugin to track unit tests coverage
This closes #673 
Example: 
https://cc.epm.kharlamov.biz/jenkins/job/Build_Legion_Artifacts/1778/
![Screenshot from 2019-03-10 18-46-19](https://user-images.githubusercontent.com/6774206/54102407-ba12af00-43e1-11e9-9abc-7a037fea2891.png)
