### PR TITLE
[#961] Jupyterlab SSO

### DIFF
--- a/containers/jupyterlab/Dockerfile
+++ b/containers/jupyterlab/Dockerfile
@@ -36,25 +36,29 @@ RUN \
   npm i -g npm@^6 && \
   rm -rf /var/lib/apt/lists/*
 
+# Install jupyterlab
+RUN pip3 install --disable-pip-version-check jupyterlab==$JUPYTERLAB_VERSION
+
 COPY legion/jupyterlab-plugin/package.json \
      legion/jupyterlab-plugin/yarn.lock \
      "${WORK_DIR}/"
 
 RUN yarn install --non-interactive --ignore-scripts
 
-COPY legion/jupyterlab-plugin/ \
+COPY legion/jupyterlab-plugin/tsconfig.json \
+     legion/jupyterlab-plugin/tslint.json \
      "${WORK_DIR}/"
+COPY legion/jupyterlab-plugin/src "${WORK_DIR}/src"
+COPY legion/jupyterlab-plugin/style "${WORK_DIR}/style"
+COPY legion/jupyterlab-plugin/jupyter-config "${WORK_DIR}/jupyter-config"
 
 RUN yarn build && yarn lint && npm pack .
-
-# Install jupyterlab
-RUN pip3 install --disable-pip-version-check jupyterlab==$JUPYTERLAB_VERSION
 
 # Run installation w/o any code to warm up nodejs cache
 RUN jupyter lab build && mv /opt/legion-plugin/jupyter_legion-*.tgz jupyter_legion.tgz
 
 RUN jupyter labextension install --no-build jupyter_legion.tgz && \
-    jupyter labextension install @jupyterlab/git jupyterlab_conda jupyterlab_toastify jupyterlab-jupytext@0.19
+    jupyter labextension install @jupyterlab/git jupyterlab_toastify jupyterlab-jupytext@0.19
 
 # We have to remove folder with node_modules and other build-related staff that is not required for running
 RUN rm -rf /usr/local/share/jupyter/lab/staging
@@ -101,8 +105,6 @@ RUN pip3 install --no-deps -e legion/sdk && \
     jupyter serverextension enable --py jupyterlab_git && \
     jupyter nbextension install --py jupytext && \
     jupyter nbextension enable --py jupytext && \
-    # jupyter_conda
-    # jupyter serverextension enable --py jupyter_conda && \
     echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' >> /etc/bash.bashrc && \
     cat /opt/legion/legion-doc.txt > /etc/motd
 

--- a/docs/source/jupyterlab_configuration.md
+++ b/docs/source/jupyterlab_configuration.md
@@ -1,0 +1,32 @@
+# Jupyterlab
+
+Legion provides the Jupyterlab plugin as part of the platform.
+
+## Internal deployment
+
+Every Legion deployment contains Jupyterlab instance.
+Its URL is `https://jupyterlab.<root-domain>/`.
+
+## Installation
+
+For now, there is no way to install the plugin from pypy\npm.
+You can use the prebuilt Docker image, which is located in [repository](https://hub.docker.com/r/legionplatformtest/jupyterlab/tags).
+
+```bash
+legionctl sandbox --image legion/jupyterlab:latest
+./legion-activate.sh
+```
+
+To setup an instance of Jupyterlab, you can use an environment variables. Available configuration options:
+* `DEFAULT_EDI_ENDPOINT` - preconfigured EDI endpoint, for example `http://edi.demo.ailifecycle.org`.
+* `LEGIONCTL_OAUTH_AUTH_URL` - Keycloak authorization endpoint, for example `https://keycloak.company.org/auth/realms/master/protocol/openid-connect/auth` 
+* `JUPYTER_REDIRECT_URL` - JupyterLab external URL.
+* `LEGIONCTL_OAUTH_SCOPE` - Oauth2 scopes. Th default value is `openid profile email offline_access groups`.
+* `LEGIONCTL_OAUTH_CLIENT_SECRET` - Oauth2 client secret
+* `LEGIONCTL_OAUTH_CLIENT_ID` - Oauth client ID
+
+To enable SSO, you should provide the following options:
+* `LEGIONCTL_OAUTH_AUTH_URL`
+* `JUPYTER_REDIRECT_URL`
+* `LEGIONCTL_OAUTH_CLIENT_SECRET`
+* `LEGIONCTL_OAUTH_CLIENT_ID`

--- a/legion/jupyterlab-plugin/legion/jupyterlab/handlers/__init__.py
+++ b/legion/jupyterlab-plugin/legion/jupyterlab/handlers/__init__.py
@@ -24,6 +24,7 @@ from legion.jupyterlab.handlers.cloud import CloudTrainingsHandler, CloudDeploym
     CloudPackagingLogsHandler, CloudUrlInfo, CloudToolchainIntegrationsHandler, CloudPackagingIntegrationsHandler, \
     CloudConfiguratioHandler
 from legion.jupyterlab.handlers.configuration import ConfigurationProviderHandler, TemplatesFilesHandler
+from legion.jupyterlab.handlers.oauth2 import OAuth2Callback, OAuth2Info
 
 # List of all back-end handlers with prefixes
 ALL_HANDLERS = (
@@ -42,6 +43,8 @@ ALL_HANDLERS = (
     (TemplatesFilesHandler, ('examples', '(.*)', 'content')),
     # Configuration
     (ConfigurationProviderHandler, ('common', 'configuration')),
+    (OAuth2Callback, ('oauth2', 'callback')),
+    (OAuth2Info, ('oauth2', 'info'))
 )
 
 

--- a/legion/jupyterlab-plugin/legion/jupyterlab/handlers/cloud.py
+++ b/legion/jupyterlab-plugin/legion/jupyterlab/handlers/cloud.py
@@ -23,7 +23,7 @@ from tornado.web import HTTPError
 
 from legion.jupyterlab.handlers.base import BaseLegionHandler
 from legion.jupyterlab.handlers.datamodels.cloud import *  # pylint: disable=W0614, W0401
-from legion.jupyterlab.handlers.helper import decorate_handler_for_exception, DEFAULT_EDI_ENDPOINT, LEGION_X_JWT_TOKEN
+from legion.jupyterlab.handlers.helper import decorate_handler_for_exception, DEFAULT_EDI_ENDPOINT
 from legion.sdk.clients.configuration import ConfigurationClient
 from legion.sdk.clients.connection import ConnectionClient
 from legion.sdk.clients.deployment import ModelDeploymentClient, ModelDeployment
@@ -64,7 +64,7 @@ class BaseCloudLegionHandler(BaseLegionHandler):
         :return: instance of target_client_class class
         """
         default_edi_url = os.getenv(DEFAULT_EDI_ENDPOINT, '')
-        jwt_header = self.request.headers.get(LEGION_X_JWT_TOKEN, '')
+        jwt_header = self.get_token_from_header()
 
         edi_url = self.request.headers.get(LEGION_CLOUD_CREDENTIALS_EDI, '')
         if not edi_url:

--- a/legion/jupyterlab-plugin/legion/jupyterlab/handlers/configuration.py
+++ b/legion/jupyterlab-plugin/legion/jupyterlab/handlers/configuration.py
@@ -19,8 +19,9 @@ Configuration handler
 import os
 
 from legion.jupyterlab.handlers.base import BaseLegionHandler
-from legion.jupyterlab.handlers.helper import decorate_handler_for_exception, LEGION_X_JWT_TOKEN, \
-    DEFAULT_EDI_ENDPOINT
+from legion.jupyterlab.handlers.helper import decorate_handler_for_exception, \
+    DEFAULT_EDI_ENDPOINT, LEGION_OAUTH_TOKEN_COOKIE_NAME
+from legion.sdk import config
 from legion.sdk.clients.templates import get_legion_template_names, get_legion_template_content
 
 
@@ -39,9 +40,12 @@ class ConfigurationProviderHandler(BaseLegionHandler):
 
         :return: None
         """
-        jwt_header = self.request.headers.get(LEGION_X_JWT_TOKEN, '')
         self.finish_with_json({
-            'tokenProvided': jwt_header != '',
+            # Verify that all parameters are set
+            'oauth2AuthorizationIsEnabled': bool(config.JUPYTER_REDIRECT_URL) and bool(
+                config.LEGIONCTL_OAUTH_AUTH_URL),
+            'idToken': self.get_cookie(LEGION_OAUTH_TOKEN_COOKIE_NAME, ''),
+            'tokenProvided': bool(self.get_token_from_header()),
             'defaultEDIEndpoint': os.getenv(DEFAULT_EDI_ENDPOINT, ''),
             'legionResourceExamples': sorted(get_legion_template_names()),
         })

--- a/legion/jupyterlab-plugin/legion/jupyterlab/handlers/helper.py
+++ b/legion/jupyterlab-plugin/legion/jupyterlab/handlers/helper.py
@@ -24,7 +24,8 @@ from legion.sdk.clients.edi import EDIConnectionException, IncorrectAuthorizatio
 
 LEGION_X_JWT_TOKEN = 'X-Jwt'
 DEFAULT_EDI_ENDPOINT = 'DEFAULT_EDI_ENDPOINT'
-DEFAULT_MODEL_ROLE = 'DEFAULT_MODEL_ROLE'
+LEGION_OAUTH_TOKEN_COOKIE_NAME = '_legion_oauth_token'
+LEGION_OAUTH_STATE_COOKIE_NAME = '_legion_oauth_state'
 
 
 def decorate_handler_for_exception(function):

--- a/legion/jupyterlab-plugin/legion/jupyterlab/handlers/oauth2.py
+++ b/legion/jupyterlab-plugin/legion/jupyterlab/handlers/oauth2.py
@@ -1,0 +1,78 @@
+#
+#    Copyright 2019 EPAM Systems
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+"""
+Oauth2 callback handler
+"""
+from legion.jupyterlab.handlers.base import build_redirect_url, build_oauth_url
+from legion.jupyterlab.handlers.cloud import BaseCloudLegionHandler
+from legion.jupyterlab.handlers.helper import decorate_handler_for_exception, LEGION_OAUTH_STATE_COOKIE_NAME, \
+    LEGION_OAUTH_TOKEN_COOKIE_NAME
+from legion.sdk.clients.oauth_handler import get_oauth_token_issuer_url, get_id_token
+
+OAUTH_STATE_ARGUMENT = 'state'
+JUPYTERLAB_MAIN_PAGE = '/lab?'
+
+
+# pylint: disable=W0223
+class OAuth2Callback(BaseCloudLegionHandler):
+    """
+    Oauth2 callback handler
+    """
+
+    @decorate_handler_for_exception
+    def get(self):
+        """
+        Retrieve and save the id token
+
+        :return: None
+        """
+        # pylint: disable=E1120
+        if self.get_argument(OAUTH_STATE_ARGUMENT) != self.get_cookie(LEGION_OAUTH_STATE_COOKIE_NAME):
+            raise ValueError('State parameters from application and authorization server are different.')
+
+        code = self.get_argument('code', strip=True)
+        target_url, _ = build_oauth_url()
+
+        issue_token_url = get_oauth_token_issuer_url(target_url)
+        if not issue_token_url:
+            raise Exception(f'Can not get URL for issuing long-life token from {target_url}')
+
+        login_result = get_id_token(code, issue_token_url, build_redirect_url())
+        if not login_result:
+            raise Exception(f'Failed to get long-life token from {issue_token_url}')
+
+        self.set_cookie(LEGION_OAUTH_TOKEN_COOKIE_NAME, login_result.id_token)
+
+        self.redirect(JUPYTERLAB_MAIN_PAGE)
+
+
+# pylint: disable=W0223
+class OAuth2Info(BaseCloudLegionHandler):
+    """
+    Oauth2 info handler
+    """
+
+    @decorate_handler_for_exception
+    def get(self):
+        """
+        Builds and returns oauth url of authorization server
+
+        :return: None
+        """
+        oauth_url, state = build_oauth_url()
+        self.set_cookie(LEGION_OAUTH_STATE_COOKIE_NAME, state)
+
+        self.finish(oauth_url)

--- a/legion/jupyterlab-plugin/src/api/cloud.ts
+++ b/legion/jupyterlab-plugin/src/api/cloud.ts
@@ -29,6 +29,7 @@ import { Connection } from '../legion/Connection';
 import { PackagingIntegration } from '../legion/PackagingIntegration';
 import { ToolchainIntegration } from '../legion/ToolchainIntegration';
 import { Configuration } from '../legion/Configuration';
+import { legionHttpExceptionHandler } from './errorHandler';
 
 export namespace URLs {
   export const configurationUrl = legionApiRootURL + '/cloud/configuration';
@@ -119,275 +120,234 @@ export interface ICloudApi {
 
 export class CloudApi implements IApiGroup, ICloudApi {
   // Trainings
+  @legionHttpExceptionHandler()
   async getModelTrainings(
     credentials: ICloudCredentials
   ): Promise<Array<ModelTraining>> {
-    try {
-      let response = await httpRequest(
-        URLs.cloudTrainingsUrl,
-        'GET',
-        null,
-        credentials
-      );
-      if (response.status !== 200) {
-        const data = await response.json();
-        throw new ServerConnection.ResponseError(response, data.message);
-      }
-      return response.json();
-    } catch (err) {
-      throw new ServerConnection.NetworkError(err);
+    let response = await httpRequest(
+      URLs.cloudTrainingsUrl,
+      'GET',
+      null,
+      credentials
+    );
+    if (response.status !== 200) {
+      const data = await response.json();
+      throw new ServerConnection.ResponseError(response, data.message);
     }
+    return response.json();
   }
 
+  @legionHttpExceptionHandler()
   async getToolchainIntegrations(
     credentials: ICloudCredentials
   ): Promise<Array<ToolchainIntegration>> {
-    try {
-      let response = await httpRequest(
-        URLs.cloudToolchainsUrl,
-        'GET',
-        null,
-        credentials
-      );
-      if (response.status !== 200) {
-        const data = await response.json();
-        throw new ServerConnection.ResponseError(response, data.message);
-      }
-      return response.json();
-    } catch (err) {
-      throw new ServerConnection.NetworkError(err);
+    let response = await httpRequest(
+      URLs.cloudToolchainsUrl,
+      'GET',
+      null,
+      credentials
+    );
+    if (response.status !== 200) {
+      const data = await response.json();
+      throw new ServerConnection.ResponseError(response, data.message);
     }
+    return response.json();
   }
 
+  @legionHttpExceptionHandler()
   async getTrainingLogs(
     request: models.ICloudTrainingLogsRequest,
     credentials: ICloudCredentials
   ): Promise<models.ICloudLogsResponse> {
-    try {
-      const url = URLs.cloudTrainingLogsUrl.replace(
-        ':trainingName:',
-        request.id
-      );
-      let response = await httpRequest(url, 'GET', undefined, credentials);
-      if (response.status !== 200) {
-        const data = await response.json();
-        throw new ServerConnection.ResponseError(response, data.message);
-      }
-      return response.json();
-    } catch (err) {
-      throw new ServerConnection.NetworkError(err);
+    const url = URLs.cloudTrainingLogsUrl.replace(':trainingName:', request.id);
+    let response = await httpRequest(url, 'GET', undefined, credentials);
+    if (response.status !== 200) {
+      const data = await response.json();
+      throw new ServerConnection.ResponseError(response, data.message);
     }
+    return response.json();
   }
 
+  @legionHttpExceptionHandler()
   async removeCloudTraining(
     request: models.IRemoveRequest,
     credentials: ICloudCredentials
   ): Promise<void> {
-    try {
-      let response = await httpRequest(
-        URLs.cloudTrainingsUrl,
-        'DELETE',
-        request,
-        credentials
-      );
-      if (response.status !== 200) {
-        const data = await response.json();
-        throw new ServerConnection.ResponseError(response, data.message);
-      }
-      return null;
-    } catch (err) {
-      throw new ServerConnection.NetworkError(err);
+    let response = await httpRequest(
+      URLs.cloudTrainingsUrl,
+      'DELETE',
+      request,
+      credentials
+    );
+    if (response.status !== 200) {
+      const data = await response.json();
+      throw new ServerConnection.ResponseError(response, data.message);
     }
+    return null;
   }
 
   // Connections
+  @legionHttpExceptionHandler()
   async getConnections(
     credentials: ICloudCredentials
   ): Promise<Array<Connection>> {
-    try {
-      let response = await httpRequest(
-        URLs.cloudConnectionsUrl,
-        'GET',
-        null,
-        credentials
-      );
-      if (response.status !== 200) {
-        const data = await response.json();
-        throw new ServerConnection.ResponseError(response, data.message);
-      }
-      return response.json();
-    } catch (err) {
-      throw new ServerConnection.NetworkError(err);
+    let response = await httpRequest(
+      URLs.cloudConnectionsUrl,
+      'GET',
+      null,
+      credentials
+    );
+    if (response.status !== 200) {
+      const data = await response.json();
+      throw new ServerConnection.ResponseError(response, data.message);
     }
+    return response.json();
   }
 
+  @legionHttpExceptionHandler()
   async removeConnection(
     request: models.IRemoveRequest,
     credentials: ICloudCredentials
   ): Promise<void> {
-    try {
-      let response = await httpRequest(
-        URLs.cloudConnectionsUrl,
-        'DELETE',
-        request,
-        credentials
-      );
-      if (response.status !== 200) {
-        const data = await response.json();
-        throw new ServerConnection.ResponseError(response, data.message);
-      }
-      return null;
-    } catch (err) {
-      throw new ServerConnection.NetworkError(err);
+    let response = await httpRequest(
+      URLs.cloudConnectionsUrl,
+      'DELETE',
+      request,
+      credentials
+    );
+    if (response.status !== 200) {
+      const data = await response.json();
+      throw new ServerConnection.ResponseError(response, data.message);
     }
+    return null;
   }
 
   // Packaging
+  @legionHttpExceptionHandler()
   async getModelPackagings(
     credentials: ICloudCredentials
   ): Promise<Array<ModelPackaging>> {
-    try {
-      let response = await httpRequest(
-        URLs.cloudModelPackagingUrl,
-        'GET',
-        null,
-        credentials
-      );
-      if (response.status !== 200) {
-        const data = await response.json();
-        throw new ServerConnection.ResponseError(response, data.message);
-      }
-      return response.json();
-    } catch (err) {
-      throw new ServerConnection.NetworkError(err);
+    let response = await httpRequest(
+      URLs.cloudModelPackagingUrl,
+      'GET',
+      null,
+      credentials
+    );
+    if (response.status !== 200) {
+      const data = await response.json();
+      throw new ServerConnection.ResponseError(response, data.message);
     }
+    return response.json();
   }
 
+  @legionHttpExceptionHandler()
   async getPackagingIntegrations(
     credentials: ICloudCredentials
   ): Promise<Array<PackagingIntegration>> {
-    try {
-      let response = await httpRequest(
-        URLs.cloudPackagingIntegrationUrl,
-        'GET',
-        null,
-        credentials
-      );
-      if (response.status !== 200) {
-        const data = await response.json();
-        throw new ServerConnection.ResponseError(response, data.message);
-      }
-      return response.json();
-    } catch (err) {
-      throw new ServerConnection.NetworkError(err);
+    let response = await httpRequest(
+      URLs.cloudPackagingIntegrationUrl,
+      'GET',
+      null,
+      credentials
+    );
+    if (response.status !== 200) {
+      const data = await response.json();
+      throw new ServerConnection.ResponseError(response, data.message);
     }
+    return response.json();
   }
 
+  @legionHttpExceptionHandler()
   async removeModelPackaging(
     request: models.IRemoveRequest,
     credentials: ICloudCredentials
   ): Promise<void> {
-    try {
-      let response = await httpRequest(
-        URLs.cloudModelPackagingUrl,
-        'DELETE',
-        request,
-        credentials
-      );
-      if (response.status !== 200) {
-        const data = await response.json();
-        throw new ServerConnection.ResponseError(response, data.message);
-      }
-      return null;
-    } catch (err) {
-      throw new ServerConnection.NetworkError(err);
+    let response = await httpRequest(
+      URLs.cloudModelPackagingUrl,
+      'DELETE',
+      request,
+      credentials
+    );
+    if (response.status !== 200) {
+      const data = await response.json();
+      throw new ServerConnection.ResponseError(response, data.message);
     }
+    return null;
   }
 
+  @legionHttpExceptionHandler()
   async getPackagingLogs(
     request: models.ICloudTrainingLogsRequest,
     credentials: ICloudCredentials
   ): Promise<models.ICloudLogsResponse> {
-    try {
-      const url = URLs.cloudPackagingLogsUrl.replace(
-        ':packagingName:',
-        request.id
-      );
-      let response = await httpRequest(url, 'GET', undefined, credentials);
-      if (response.status !== 200) {
-        const data = await response.json();
-        throw new ServerConnection.ResponseError(response, data.message);
-      }
-      return response.json();
-    } catch (err) {
-      throw new ServerConnection.NetworkError(err);
+    const url = URLs.cloudPackagingLogsUrl.replace(
+      ':packagingName:',
+      request.id
+    );
+    let response = await httpRequest(url, 'GET', undefined, credentials);
+    if (response.status !== 200) {
+      const data = await response.json();
+      throw new ServerConnection.ResponseError(response, data.message);
     }
+    return response.json();
   }
 
   // Deployments
+  @legionHttpExceptionHandler()
   async getCloudDeployments(
     credentials: ICloudCredentials
   ): Promise<Array<ModelDeployment>> {
-    try {
-      let response = await httpRequest(
-        URLs.cloudDeploymentsUrl,
-        'GET',
-        null,
-        credentials
-      );
-      if (response.status !== 200) {
-        const data = await response.json();
-        throw new ServerConnection.ResponseError(response, data.message);
-      }
-      return response.json();
-    } catch (err) {
-      throw new ServerConnection.NetworkError(err);
+    let response = await httpRequest(
+      URLs.cloudDeploymentsUrl,
+      'GET',
+      null,
+      credentials
+    );
+    if (response.status !== 200) {
+      const data = await response.json();
+      throw new ServerConnection.ResponseError(response, data.message);
     }
+    return response.json();
   }
 
+  @legionHttpExceptionHandler()
   async createCloudDeployment(
     request: ModelDeployment,
     credentials: ICloudCredentials
   ): Promise<ModelDeployment> {
-    try {
-      let response = await httpRequest(
-        URLs.cloudDeploymentsUrl,
-        'POST',
-        request,
-        credentials
-      );
-      if (response.status !== 200) {
-        const data = await response.json();
-        throw new ServerConnection.ResponseError(response, data.message);
-      }
-      return response.json();
-    } catch (err) {
-      throw new ServerConnection.NetworkError(err);
+    let response = await httpRequest(
+      URLs.cloudDeploymentsUrl,
+      'POST',
+      request,
+      credentials
+    );
+    if (response.status !== 200) {
+      const data = await response.json();
+      throw new ServerConnection.ResponseError(response, data.message);
     }
+    return response.json();
   }
 
+  @legionHttpExceptionHandler()
   async removeCloudDeployment(
     request: models.IRemoveRequest,
     credentials: ICloudCredentials
   ): Promise<void> {
-    try {
-      let response = await httpRequest(
-        URLs.cloudDeploymentsUrl,
-        'DELETE',
-        request,
-        credentials
-      );
-      if (response.status !== 200) {
-        const data = await response.json();
-        throw new ServerConnection.ResponseError(response, data.message);
-      }
-      return null;
-    } catch (err) {
-      throw new ServerConnection.NetworkError(err);
+    let response = await httpRequest(
+      URLs.cloudDeploymentsUrl,
+      'DELETE',
+      request,
+      credentials
+    );
+    if (response.status !== 200) {
+      const data = await response.json();
+      throw new ServerConnection.ResponseError(response, data.message);
     }
+    return null;
   }
 
   // Aggregated
+  @legionHttpExceptionHandler()
   async getCloudAllEntities(
     credentials: ICloudCredentials
   ): Promise<models.ICloudAllEntitiesResponse> {
@@ -423,45 +383,39 @@ export class CloudApi implements IApiGroup, ICloudApi {
   }
 
   // General
+  @legionHttpExceptionHandler()
   async applyFromFile(
     request: models.IApplyFromFileRequest,
     credentials: ICloudCredentials
   ): Promise<models.IApplyFromFileResponse> {
-    try {
-      let response = await httpRequest(
-        URLs.cloudApplyFileUrl,
-        'POST',
-        request,
-        credentials
-      );
-      if (response.status !== 200) {
-        const data = await response.json();
-        throw new ServerConnection.ResponseError(response, data.message);
-      }
-      return response.json();
-    } catch (err) {
-      throw new ServerConnection.NetworkError(err);
+    let response = await httpRequest(
+      URLs.cloudApplyFileUrl,
+      'POST',
+      request,
+      credentials
+    );
+    if (response.status !== 200) {
+      const data = await response.json();
+      throw new ServerConnection.ResponseError(response, data.message);
     }
+    return response.json();
   }
 
   // Configuration
+  @legionHttpExceptionHandler()
   async getConfiguration(
     credentials: ICloudCredentials
   ): Promise<Configuration> {
-    try {
-      let response = await httpRequest(
-        URLs.configurationUrl,
-        'GET',
-        null,
-        credentials
-      );
-      if (response.status !== 200) {
-        const data = await response.json();
-        throw new ServerConnection.ResponseError(response, data.message);
-      }
-      return response.json();
-    } catch (err) {
-      throw new ServerConnection.NetworkError(err);
+    let response = await httpRequest(
+      URLs.configurationUrl,
+      'GET',
+      null,
+      credentials
+    );
+    if (response.status !== 200) {
+      const data = await response.json();
+      throw new ServerConnection.ResponseError(response, data.message);
     }
+    return response.json();
   }
 }

--- a/legion/jupyterlab-plugin/src/api/configuration.ts
+++ b/legion/jupyterlab-plugin/src/api/configuration.ts
@@ -17,51 +17,53 @@ import { ServerConnection } from '@jupyterlab/services';
 
 import { httpRequest, IApiGroup, legionApiRootURL } from './base';
 import * as models from '../models/configuration';
+import { legionHttpExceptionHandler } from './errorHandler';
 
 export namespace URLs {
   export const configurationUrl = legionApiRootURL + '/common/configuration';
+  export const oauthInfoUrl = legionApiRootURL + '/oauth2/info';
   export const exampleContentUrl = legionApiRootURL + '/examples/:name/content';
 }
 
 export interface IConfigurationApi {
   getCloudConfiguration: () => Promise<models.IConfigurationMainResponse>;
   getExampleContent: (name: string) => Promise<string>;
+  getOauthUrl: () => Promise<string>;
 }
 
 export class ConfigurationApi implements IApiGroup, IConfigurationApi {
+  @legionHttpExceptionHandler()
   async getCloudConfiguration(): Promise<models.IConfigurationMainResponse> {
-    try {
-      let response = await httpRequest(
-        URLs.configurationUrl,
-        'GET',
-        null,
-        null
-      );
-      if (response.status !== 200) {
-        const data = await response.json();
-        throw new ServerConnection.ResponseError(response, data.message);
-      }
-      return response.json();
-    } catch (err) {
-      throw new ServerConnection.NetworkError(err);
+    let response = await httpRequest(URLs.configurationUrl, 'GET', null, null);
+    if (response.status !== 200) {
+      const data = await response.json();
+      throw new ServerConnection.ResponseError(response, data.message);
     }
+    return await response.json();
   }
 
+  @legionHttpExceptionHandler()
   async getExampleContent(name: string): Promise<string> {
-    try {
-      let response = await httpRequest(
-        URLs.exampleContentUrl.replace(':name', name),
-        'GET',
-        null,
-        null
-      );
-      if (response.status !== 200) {
-        const data = await response.json();
-        throw new ServerConnection.ResponseError(response, data.message);
-      }
-      return response.text();
-    } catch (err) {
-      throw new ServerConnection.NetworkError(err);
+    let response = await httpRequest(
+      URLs.exampleContentUrl.replace(':name', name),
+      'GET',
+      null,
+      null
+    );
+    if (response.status !== 200) {
+      const data = await response.json();
+      throw new ServerConnection.ResponseError(response, data.message);
     }
+    return response.text();
+  }
+
+  @legionHttpExceptionHandler()
+  async getOauthUrl(): Promise<string> {
+    let response = await httpRequest(URLs.oauthInfoUrl, 'GET', null, null);
+    if (response.status !== 200) {
+      const data = await response.json();
+      throw new ServerConnection.ResponseError(response, data.message);
+    }
+    return response.text();
   }
 }

--- a/legion/jupyterlab-plugin/src/api/errorHandler.ts
+++ b/legion/jupyterlab-plugin/src/api/errorHandler.ts
@@ -1,0 +1,51 @@
+/**
+ *   Copyright 2019 EPAM Systems
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+import { ServerConnection } from '@jupyterlab/services';
+import {
+  LEGION_OAUTH_TOKEN_COOKIE_NAME,
+  PLUGIN_CREDENTIALS_STORE_TOKEN
+} from '../models/apiState';
+import ResponseError = ServerConnection.ResponseError;
+
+const HTTP_STATUS_CODE_FORBIDDEN = 403;
+
+export function legionHttpExceptionHandler() {
+  return (
+    target: any,
+    propertyKey: string,
+    descriptor: TypedPropertyDescriptor<(...params: any[]) => Promise<any>>
+  ) => {
+    let oldFunc = descriptor.value;
+    descriptor.value = async function() {
+      try {
+        return await oldFunc.apply(this, arguments); // tslint:disable-line
+      } catch (err) {
+        // If we get 403 from legion plugin then the token is obsolete.
+        if (
+          err instanceof ResponseError &&
+          err.response.status === HTTP_STATUS_CODE_FORBIDDEN
+        ) {
+          // Cleanup legion token from local storage store
+          localStorage.removeItem(PLUGIN_CREDENTIALS_STORE_TOKEN);
+          // Cleanup legion token from cookie
+          document.cookie = `${LEGION_OAUTH_TOKEN_COOKIE_NAME}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+        }
+
+        throw new ServerConnection.NetworkError(err);
+      }
+    };
+  };
+}

--- a/legion/jupyterlab-plugin/src/commands/authorize.ts
+++ b/legion/jupyterlab-plugin/src/commands/authorize.ts
@@ -13,7 +13,8 @@
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-import { showErrorMessage, showDialog, Dialog } from '@jupyterlab/apputils';
+import { Dialog, showDialog, showErrorMessage } from '@jupyterlab/apputils';
+import { CommandRegistry } from '@phosphor/commands';
 
 import { CommandIDs, IAddCloudCommandsOptions } from './base';
 import * as dialogs from '../components/dialogs';
@@ -63,34 +64,85 @@ export function addCommands(options: IAddCloudCommandsOptions) {
             'Can not authorize on a cluster',
             'You are already authorized'
           );
+        } else if (
+          options.state.authConfiguration.oauth2AuthorizationIsEnabled
+        ) {
+          oauth2Authentication(options);
         } else {
-          dialogs.showLoginDialog().then(({ button, value }) => {
-            if (button.accept) {
-              let splashScreen = options.splash.show();
-              options.api.cloud
-                .getCloudAllEntities(value)
-                .then(_ => {
-                  splashScreen.dispose();
-                  options.state.setCredentials(value);
-                  showDialog({
-                    title: 'Legion Cluster mode',
-                    body:
-                      'You have been successfully authorized on a cluster ' +
-                      value.cluster,
-                    buttons: [Dialog.okButton()]
-                  });
-                  commands.execute(CommandIDs.refreshCloud);
-                })
-                .catch(err => {
-                  splashScreen.dispose();
-                  showErrorMessage('Authorization on a cluster failed', err);
-                });
-            }
-          });
+          authenticateUsingToken(options, commands);
         }
       } catch (err) {
         showErrorMessage('Can not authorize on a cluster', err);
       }
     }
   });
+}
+
+function authenticateUsingToken(
+  options: IAddCloudCommandsOptions,
+  commands: CommandRegistry
+) {
+  dialogs
+    .showLoginDialog(options.state.credentials.cluster)
+    .then(({ button, value }) => {
+      if (button.accept) {
+        let splashScreen = options.splash.show();
+        options.api.cloud
+          .getCloudAllEntities(value)
+          .then(_ => {
+            splashScreen.dispose();
+            options.state.setCredentials(value);
+            showDialog({
+              title: 'Legion Cluster mode',
+              body:
+                'You have been successfully authorized on a cluster ' +
+                value.cluster,
+              buttons: [Dialog.okButton()]
+            });
+            commands.execute(CommandIDs.refreshCloud);
+          })
+          .catch(err => {
+            splashScreen.dispose();
+            showErrorMessage('Authorization on a cluster failed', err);
+          });
+      }
+    });
+}
+
+function oauth2Authentication(options: IAddCloudCommandsOptions) {
+  if (options.state.credentials.cluster) {
+    let splashScreen = options.splash.show();
+
+    options.api.configuration
+      .getOauthUrl()
+      .then(function(oauthUrl) {
+        splashScreen.dispose();
+
+        window.location.assign(oauthUrl);
+      })
+      .catch(err => {
+        splashScreen.dispose();
+      });
+  } else {
+    dialogs
+      .showLoginDialog(options.state.credentials.cluster, false)
+      .then(({ button, value }) => {
+        if (button.accept) {
+          let splashScreen = options.splash.show();
+
+          options.state.setCredentials(value);
+          options.api.configuration
+            .getOauthUrl()
+            .then(oauthUrl => {
+              splashScreen.dispose();
+
+              window.location.assign(oauthUrl);
+            })
+            .catch(err => {
+              splashScreen.dispose();
+              showErrorMessage('Authorization on a cluster failed', err);
+            });
+        }
+      });
+  }
 }

--- a/legion/jupyterlab-plugin/src/components/dialogs/authorize.ts
+++ b/legion/jupyterlab-plugin/src/components/dialogs/authorize.ts
@@ -24,11 +24,18 @@ interface ILoginDialogValues {
 }
 
 class LoginDialog extends Widget {
+  private readonly tokenRequired: boolean;
+
   /**
    * Construct a new "rename" dialog.
+   * @param defaultEdiUrl - default EDI URL
+   * @param tokenRequired - If it equals true then the widget creates input field for a Legion token.
    */
-  constructor() {
-    super({ node: Private.buildAuthorizeDialogBody() });
+  constructor(defaultEdiUrl: string, tokenRequired: boolean = true) {
+    super({
+      node: Private.buildAuthorizeDialogBody(defaultEdiUrl, tokenRequired)
+    });
+    this.tokenRequired = tokenRequired;
   }
 
   getInputNodeValue(no: number): string {
@@ -46,15 +53,18 @@ class LoginDialog extends Widget {
   getValue(): ILoginDialogValues {
     return {
       cluster: this.getInputNodeValue(0),
-      authString: this.getInputNodeValue(1)
+      authString: this.tokenRequired ? this.getInputNodeValue(1) : ''
     };
   }
 }
 
-export function showLoginDialog() {
+export function showLoginDialog(
+  defaultEdiUrl: string,
+  tokenRequired: boolean = true
+) {
   return showDialog({
     title: 'Authorization on a Legion cluster',
-    body: new LoginDialog(),
+    body: new LoginDialog(defaultEdiUrl, tokenRequired),
     buttons: [Dialog.cancelButton(), Dialog.okButton({ label: 'Login' })]
   });
 }
@@ -71,18 +81,26 @@ export function showLogoutDialog(clusterName) {
 }
 
 namespace Private {
-  export function buildAuthorizeDialogBody() {
+  export function buildAuthorizeDialogBody(
+    defaultEdiUrl: string,
+    tokenRequired: boolean = true
+  ) {
     let body = base.createDialogBody();
 
     body.appendChild(base.createDialogInputLabel('Cluster (EDI) url'));
     body.appendChild(
-      base.createDialogInput(undefined, 'https://edi-company-a.example.com')
+      base.createDialogInput(defaultEdiUrl, 'https://edi-company-a.example.com')
     );
 
-    body.appendChild(base.createDialogInputLabel('Oauth2 token'));
-    body.appendChild(
-      base.createDialogInput(undefined, 'ZW1haWw6dGVzdHMtdXNlckBsZWdpb24uY....')
-    );
+    if (tokenRequired) {
+      body.appendChild(base.createDialogInputLabel('Oauth2 token'));
+      body.appendChild(
+        base.createDialogInput(
+          undefined,
+          'ZW1haWw6dGVzdHMtdXNlckBsZWdpb24uY....'
+        )
+      );
+    }
 
     return body;
   }

--- a/legion/jupyterlab-plugin/src/index.ts
+++ b/legion/jupyterlab-plugin/src/index.ts
@@ -338,7 +338,7 @@ function activateCloudPlugin(
       if (response.defaultEDIEndpoint.length !== 0) {
         legionExtension.apiCloudState.setCredentials({
           cluster: response.defaultEDIEndpoint,
-          authString: ''
+          authString: null
         });
       } else {
         mainMenu.addMenu(

--- a/legion/jupyterlab-plugin/src/models/configuration.ts
+++ b/legion/jupyterlab-plugin/src/models/configuration.ts
@@ -16,6 +16,8 @@
 
 export interface IConfigurationMainResponse {
   tokenProvided: boolean;
+  oauth2AuthorizationIsEnabled: boolean;
+  idToken: string;
   defaultEDIEndpoint: string;
   legionResourceExamples: Array<string>;
 }

--- a/legion/jupyterlab-plugin/tsconfig.json
+++ b/legion/jupyterlab-plugin/tsconfig.json
@@ -8,6 +8,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "es2015",
+    "experimentalDecorators": true,
     "outDir": "lib",
     "lib": ["es5", "es6", "es2015.promise", "es2015.collection", "dom"],
     "types": [],

--- a/legion/sdk/legion/sdk/clients/oauth_handler.py
+++ b/legion/sdk/legion/sdk/clients/oauth_handler.py
@@ -193,6 +193,10 @@ def get_id_token(code: str, issue_token_url: str, redirect_uri: str) -> typing.O
         'code': code,
         'redirect_uri': redirect_uri
     }
+
+    if config.LEGIONCTL_OAUTH_CLIENT_SECRET:
+        payload['client_secret'] = config.LEGIONCTL_OAUTH_CLIENT_SECRET
+
     return _ask_token_endpoint(issue_token_url, payload)
 
 

--- a/legion/sdk/legion/sdk/config.py
+++ b/legion/sdk/legion/sdk/config.py
@@ -518,6 +518,10 @@ LEGIONCTL_OAUTH_CLIENT_ID = ConfigVariableDeclaration('LEGIONCTL_OAUTH_CLIENT_ID
                                                       'Set OAuth2 Client id',
                                                       True)
 
+LEGIONCTL_OAUTH_CLIENT_SECRET = ConfigVariableDeclaration('LEGIONCTL_OAUTH_CLIENT_SECRET', '', str,
+                                                          'Set OAuth2 Client id',
+                                                          True)
+
 LEGIONCTL_OAUTH_SCOPE = ConfigVariableDeclaration('LEGIONCTL_OAUTH_SCOPE',
                                                   'openid profile email offline_access groups', str,
                                                   'Set OAuth2 scope',
@@ -529,14 +533,25 @@ LEGIONCTL_OAUTH_LOOPBACK_HOST = ConfigVariableDeclaration('LEGIONCTL_OAUTH_LOOPB
                                                           True)
 
 LEGIONCTL_OAUTH_LOOPBACK_URL = ConfigVariableDeclaration('LEGIONCTL_OAUTH_LOOPBACK_URL',
-                                                          '/oauth/callback', str,
-                                                          'Target redirect url for OAuth2 interactive authorization',
-                                                          True)
+                                                         '/oauth/callback', str,
+                                                         'Target redirect url for OAuth2 interactive authorization',
+                                                         True)
 
 LEGIONCTL_OAUTH_TOKEN_ISSUING_URL = ConfigVariableDeclaration('LEGIONCTL_OAUTH_TOKEN_ISSUING_URL',
                                                               '', str,
                                                               'OAuth2 token issuing URL',
                                                               True)
+
+LEGIONCTL_OAUTH_AUTH_URL = ConfigVariableDeclaration('LEGIONCTL_OAUTH_AUTH_URL',
+                                                     '',
+                                                     str,
+                                                     'OAuth2 token issuing URL',
+                                                     True)
+
+JUPYTER_REDIRECT_URL = ConfigVariableDeclaration('JUPYTER_REDIRECT_URL',
+                                                 '', str,
+                                                 'JupyterLab external URL',
+                                                 True)
 
 LEGIONCTL_NONINTERACTIVE = ConfigVariableDeclaration('LEGIONCTL_NONINTERACTIVE', False,
                                                      bool, 'Disable any interaction (e.g. authorization)', True)


### PR DESCRIPTION
* Implements SSO with Keycloak
* Supported three authorization ways:
  * manually by url\token
  * authentication on a keycloak
  * token through oauth proxy header
* Extract common API code to the decorator function
* Reset the token in case of 403 response code
* Optimize Jupyterlab Docker build