### PR TITLE
[#fix] typo: token should be used but not url for auth parameter in h…

### DIFF
--- a/legion/operator/pkg/repository/util/http/request.go
+++ b/legion/operator/pkg/repository/util/http/request.go
@@ -79,7 +79,7 @@ func (bec *BaseEdiClient) DoRequest(httpMethod, path string, body interface{}) (
 		URL:    ediURL,
 		Header: map[string][]string{
 			authorizationHeaderName: {
-				fmt.Sprintf(authorizationHeaderValue, bec.ediURL),
+				fmt.Sprintf(authorizationHeaderValue, bec.token),
 			},
 		},
 		Body: bodyStream,


### PR DESCRIPTION
[#fix] typo: token should be used but not url for auth parameter in http request