### PR TITLE
[#1031] Azure Storage SAS Token for fluend

### DIFF
--- a/containers/fluentd/Dockerfile
+++ b/containers/fluentd/Dockerfile
@@ -18,6 +18,8 @@ FROM fluent/fluentd:v1.7
 
 USER root
 
+ARG REPO_URL=https://github.com/legion-platform/fluent-plugin-azure-storage-append-blob.git
+
 # Install required fluentd plugins
 RUN apk update \
  && apk add --no-cache --virtual .build-deps \
@@ -25,7 +27,7 @@ RUN apk update \
         ruby-dev gnupg zlib-dev \
  && gem install fluent-plugin-s3 -v 1.1.11 \
  && gem install fluent-plugin-gcs -v 0.4.0 \
- && git clone https://github.com/maxkochubey/fluent-plugin-azure-storage-append-blob.git /tmp/build-azure \
+ && git clone ${REPO_URL} /tmp/build-azure \
  && cd /tmp/build-azure && gem build *.gemspec && gem install *.gem \
  && apk del .build-deps \
  && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem

--- a/containers/fluentd/Dockerfile
+++ b/containers/fluentd/Dockerfile
@@ -19,6 +19,7 @@ FROM fluent/fluentd:v1.7
 USER root
 
 ARG REPO_URL=https://github.com/legion-platform/fluent-plugin-azure-storage-append-blob.git
+ARG GIT_PARAMS="-c advice.detachedHead=false clone --branch 0.1.1"
 
 # Install required fluentd plugins
 RUN apk update \
@@ -27,7 +28,7 @@ RUN apk update \
         ruby-dev gnupg zlib-dev \
  && gem install fluent-plugin-s3 -v 1.1.11 \
  && gem install fluent-plugin-gcs -v 0.4.0 \
- && git clone ${REPO_URL} /tmp/build-azure \
+ && git ${GIT_PARAMS} ${REPO_URL} /tmp/build-azure \
  && cd /tmp/build-azure && gem build *.gemspec && gem install *.gem \
  && apk del .build-deps \
  && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem

--- a/containers/fluentd/Dockerfile
+++ b/containers/fluentd/Dockerfile
@@ -21,10 +21,11 @@ USER root
 # Install required fluentd plugins
 RUN apk update \
  && apk add --no-cache --virtual .build-deps \
-        build-base \
+        build-base git \
         ruby-dev gnupg zlib-dev \
  && gem install fluent-plugin-s3 -v 1.1.11 \
  && gem install fluent-plugin-gcs -v 0.4.0 \
- && gem install fluent-plugin-azure-storage-append-blob -v 0.1.1 \
+ && git clone https://github.com/maxkochubey/fluent-plugin-azure-storage-append-blob.git /tmp/build-azure \
+ && cd /tmp/build-azure && gem build *.gemspec && gem install *.gem \
  && apk del .build-deps \
  && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem

--- a/containers/fluentd/Dockerfile
+++ b/containers/fluentd/Dockerfile
@@ -14,13 +14,17 @@
 #    limitations under the License.
 #
 
-FROM fluent/fluentd:v1.7-debian as builder
+FROM fluent/fluentd:v1.7
+
 USER root
-RUN apt-get -qq update && apt-get -y install zlib1g-dev libxml2-dev gcc make patch
 
 # Install required fluentd plugins
-RUN gem install -N fluent-plugin-s3:1.1.11 fluent-plugin-gcs:0.4.0 fluent-plugin-azure-storage-append-blob:0.1.1
-
-FROM fluent/fluentd:v1.7-debian
-
-COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
+RUN apk update \
+ && apk add --no-cache --virtual .build-deps \
+        build-base \
+        ruby-dev gnupg zlib-dev \
+ && gem install fluent-plugin-s3 -v 1.1.11 \
+ && gem install fluent-plugin-gcs -v 0.4.0 \
+ && gem install fluent-plugin-azure-storage-append-blob -v 0.1.1 \
+ && apk del .build-deps \
+ && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem

--- a/containers/fluentd/docker-compose.yaml
+++ b/containers/fluentd/docker-compose.yaml
@@ -22,9 +22,8 @@ version: "3"
 
 services:
   fluentd:
-    image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
-    environment:
-      - FLUENTD_ARGS=-c /opt/fluent-config/fluent.conf
+    image: fluent/fluentd:v1.7
+    command: -c /opt/fluent-config/fluent.conf
     ports:
       - 24224:24224/tcp
       - 24224:24224/udp

--- a/helms/legion/templates/fluentd/config-values.yaml
+++ b/helms/legion/templates/fluentd/config-values.yaml
@@ -79,8 +79,11 @@ data:
       azure_storage_account "#{ENV['AZURE_STORAGE_ACCOUNT']}"
       azure_storage_access_key "#{ENV['AZURE_STORAGE_ACCESS_KEY']}"
       {{- end }}
-      {{- if eq .Values.feedback.output.azureblob.authorization "sas" }}
-      # TODO: Auth based on Shared Access Signature (SAS Token) for Storage Account
+      {{- if eq .Values.feedback.output.azureblob.authorization "sastoken" }}
+      # Auth based on secrets from HELM configuration
+      # Secrets are attached as secretKeyRefs from "{{ .Release.Name }}-fluentd-secret" secret
+      azure_storage_account "#{ENV['AZURE_STORAGE_ACCOUNT']}"
+      azure_storage_sas_token "#{ENV['AZURE_STORAGE_SAS_TOKEN']}"
       {{- end }}
 
       # Storing

--- a/helms/legion/templates/fluentd/fluentd-secrets.yaml
+++ b/helms/legion/templates/fluentd/fluentd-secrets.yaml
@@ -52,5 +52,17 @@ data:
   AzureStorageAccount: "{{ required "Azure Storage Account Name" .Values.feedback.output.azureblob.AzureStorageAccount | b64enc }}"
   AzureStorageAccessKey: "{{ required "Azure Storage Access Key (Primary or Secondary)" .Values.feedback.output.azureblob.AzureStorageAccessKey | b64enc }}"
 {{- end }}
+{{- if eq .Values.feedback.output.azureblob.authorization "sastoken" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ .Release.Name }}-fluentd-secret"
+  labels:
+    {{- include "legion.helm-labels" (dict "component" "fluentd" "root" .) | nindent 4 }}
+type: Opaque
+data:
+  AzureStorageAccount: "{{ required "Azure Storage Account Name" .Values.feedback.output.azureblob.AzureStorageAccount | b64enc }}"
+  AzureStorageSasToken: "{{ required "Azure Storage SAS Token" .Values.feedback.output.azureblob.AzureStorageSasToken | b64enc }}"
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helms/legion/templates/fluentd/server.yaml
+++ b/helms/legion/templates/fluentd/server.yaml
@@ -62,6 +62,18 @@ spec:
               name: "{{ .Release.Name }}-fluentd-secret"
               key: AzureStorageAccessKey
         {{- end }}
+        {{- if eq .Values.feedback.output.azureblob.authorization "sastoken" }}
+        - name: AZURE_STORAGE_ACCOUNT
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Release.Name }}-fluentd-secret"
+              key: AzureStorageAccount
+        - name: AZURE_STORAGE_SAS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Release.Name }}-fluentd-secret"
+              key: AzureStorageSasToken
+        {{- end }}
         {{- end }}
         ports:
         - containerPort: {{ .Values.feedback.fluentd.port }}

--- a/helms/legion/values.yaml
+++ b/helms/legion/values.yaml
@@ -364,16 +364,22 @@ feedback:
       # Type of authorization in Azure Blob storage
       # Valid values are:
       #   - accesskey
-      #   - sas
-      authorization: "accesskey"
+      #   - sastoken
+      authorization: "sastoken"
 
-      #
+      # Name of Azure Storage Account
       # Type: string
       #AzureStorageAccount: ~
 
-      #
+      # One of two keys that used to authorize access to Azure storage account
       # Type: string
       #AzureStorageAccessKey: ~
+
+      # A shared access signature (SAS) is a signed URI that points to one or more storage
+      # resources and includes a token that contains a special set of query parameters.
+      # This variable should contain SAS token to Azure Blob storage service account.
+      # Type: string
+      #AzureStorageSasToken: ~
 
       # Azure Blob container name
       # Type: string


### PR DESCRIPTION
- `fluentd` container now is alpine-based (137 MiB against 338 MiB of old debian-based image)
- Fluent is using modified `fluent-plugin-azure-storage-append-blob` plugin from Microsoft
- Azure Blob Storage authentication switched to shared access signature (SAS)

This PR closes #1031.