### PR TITLE
[#1037] Remove sensitive information from feedback

### DIFF
--- a/helms/legion/templates/feedback/collector.yaml
+++ b/helms/legion/templates/feedback/collector.yaml
@@ -28,6 +28,8 @@ data:
                       - "{{ .Release.Name }}-fluentd.{{ .Release.Namespace }}.svc.cluster.local"
                       - "--fluentd-port"
                       - "24224"
+                      - "--prohibited-headers"
+                      - "{{ .Values.feedback.collector.prohibited_headers | join "," }}"
                   ports:
                       - containerPort: 7777
                         name: api

--- a/helms/legion/values.yaml
+++ b/helms/legion/values.yaml
@@ -197,6 +197,15 @@ feedback:
     # Type: string
     # image: custom-image:1.0
 
+    # The list of headers which will be skipped during feedback
+    # Pay attention! The headers must be in lowercase format.
+    # Type: list of strings
+    prohibited_headers:
+      - authorization
+      - x-jwt
+      - x-user
+      - x-email
+
     # Resources for each instance
     # For declaration format see https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     resources:

--- a/legion/feedback-aggregator/cmd/collector/main.go
+++ b/legion/feedback-aggregator/cmd/collector/main.go
@@ -58,7 +58,9 @@ func entrypoint(cmd *cobra.Command, args []string) {
 		viper.GetString(tapping.CfgEnvoyHost),
 		viper.GetInt(tapping.CfgEnvoyPort),
 		viper.GetString(tapping.CfgEnvoyConfigId),
-		dataLogger)
+		dataLogger,
+		viper.GetStringSlice(feedback.CfgProhibitedHeaders),
+	)
 	if err != nil {
 		log.Error(err, "Collector creation")
 		os.Exit(1)

--- a/legion/feedback-aggregator/pkg/feedback/config.go
+++ b/legion/feedback-aggregator/pkg/feedback/config.go
@@ -11,10 +11,12 @@ import (
 const (
 	CfgFluentdHost          = "fluentd.host"
 	CfgFluentdPort          = "fluentd.port"
+	CfgProhibitedHeaders    = "prohibited_headers"
 	CfgRequestResponseTag   = "tags.request_response"
 	CfgResponseBodyTag      = "tags.response_body"
 	CfgFeedbackTag          = "tags.feedback"
 	defaultConfigPathForDev = "legion/feedback-aggregator"
+	cmdProhibitedHeaders    = "prohibited-headers"
 	cmdFluentHost           = "fluentd-host"
 	cmdFluentdPort          = "fluentd-port"
 )
@@ -31,10 +33,17 @@ func InitBasicParams(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&CfgFile, "config", "", "config file")
 	cmd.Flags().String(cmdFluentHost, "127.0.0.1", "Fluentd host")
 	cmd.Flags().Int(cmdFluentdPort, 24224, "Fluentd port")
+	cmd.Flags().StringSlice(
+		cmdProhibitedHeaders,
+		[]string{},
+		"List of prohibited headers which will be skipped from feedback",
+	)
 
 	PanicIfError(viper.BindPFlag(CfgFluentdHost, cmd.Flags().Lookup(cmdFluentHost)))
 	PanicIfError(viper.BindPFlag(CfgFluentdPort, cmd.Flags().Lookup(cmdFluentdPort)))
+	PanicIfError(viper.BindPFlag(CfgProhibitedHeaders, cmd.Flags().Lookup(cmdProhibitedHeaders)))
 
+	viper.SetDefault(CfgProhibitedHeaders, []string{"authorization", "x-jwt", "x-user", "x-email"})
 	viper.SetDefault(CfgRequestResponseTag, "request_response")
 	viper.SetDefault(CfgResponseBodyTag, "response_body")
 	viper.SetDefault(CfgFeedbackTag, "feedback")

--- a/legion/tests/e2e/robot/tests/deployment/feedback.robot
+++ b/legion/tests/e2e/robot/tests/deployment/feedback.robot
@@ -26,6 +26,7 @@ Force Tags          deployment  edi  cli  feedback
 
 *** Variables ***
 ${REQUEST_ID_CHECK_RETRIES}         30
+@{FORBIDDEN_HEADERS}  authorization  x-jwt  x-user  x-email
 
 *** Keywords ***
 Cleanup resources
@@ -51,7 +52,6 @@ Validate model API meta log entry
     Dictionary Should Contain Key   ${log_entry}  request_http_headers
     Dictionary Should Contain Key   ${log_entry}  request_host
     Dictionary Should Contain Key   ${log_entry}  request_uri
-    Dictionary Should Contain Key   ${log_entry}  response_http_headers
     Dictionary Should Contain Key   ${log_entry}  response_status
     Dictionary Should Contain Key   ${log_entry}  model_name
     Dictionary Should Contain Key   ${log_entry}  model_version
@@ -67,6 +67,15 @@ Validate model API meta log entry HTTP method
     [Arguments]      ${log_entry}   ${excpected_value}
     ${http_method}=                 Get From Dictionary       ${log_entry}     request_http_method
     Should Be Equal                 ${http_method}            ${excpected_value}
+
+Validate model API meta log entry HTTP headers
+    [Documentation]  check that model API log entry HTTP headers do not have a forbidden header
+    [Arguments]      ${log_entry}
+    ${request_http_headers}=                 Get From Dictionary       ${log_entry}     request_http_headers
+
+    FOR    ${header}    IN    @{FORBIDDEN_HEADERS}
+        Dictionary should not contain key  ${request_http_headers}  ${header}
+    END
 
 Validate model API meta log entry POST arguments
     [Documentation]  check that model API log entry POST arguments are correct
@@ -155,6 +164,7 @@ Validate model feedback
     Validate model API meta log entry Request ID        ${meta_log_entry}   ${request_id}
     Validate model API meta log entry HTTP method       ${meta_log_entry}   POST
     Validate model API meta ID and version              ${meta_log_entry}   ${TEST_MODEL_NAME}  ${TEST_MODEL_VERSION}
+    Validate model API meta log entry HTTP headers      ${meta_log_entry}
 
     ${body_log_locations}=             Get paths with lag  ${FEEDBACK_LOCATION_MODELS_RESP_LOG}  ${TEST_MODEL_NAME}  ${TEST_MODEL_VERSION}  ${FEEDBACK_PARTITIONING_PATTERN}
     @{response_log_entries}=           Find log lines with content   ${body_log_locations}  ${request_id}  ${1}  ${False}


### PR DESCRIPTION
Some headers from a model request can contain some sensitive
information: token, password, and so on. The feedback collector service
must not send it to Fluentd service.

To fix it, we introduce the new config option that allows specifying
a list of forbidden headers. A user can pass this parameter through
helm values too.
The default list of forbidden headers is:
  - authorization
  - x-jwt
  - x-user
  - x-email

Moreover, we improve robot feedback test to check that feedback does
not contain forbidden headers.

This closes #1037 